### PR TITLE
refactor: create hasBeenCalledWithParams method

### DIFF
--- a/force-app/classes/src/Assertions.cls
+++ b/force-app/classes/src/Assertions.cls
@@ -57,7 +57,7 @@ public class Assertions {
       this.hasBeenCalledWith(new List<Object>{ params });
     }
 
-    public void hasBeenCalledWith(ParametersMatcher matcher) {
+    public void hasBeenCalledWithParams(ParametersMatcher matcher) {
       System.assertNotEquals(
         null,
         spy.getLastCallParams(),
@@ -68,7 +68,7 @@ public class Assertions {
       matcher.assertMatches(spy.getLastCallParams());
     }
 
-    public void hasBeenCalledWith(List<Object> params) {
+    public void hasBeenCalledWithParams(List<Object> params) {
       System.assertNotEquals(
         null,
         spy.getLastCallParams(),

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -40,14 +40,6 @@ public class MethodSpy {
     return this.callCount == count;
   }
 
-  public Object call() {
-    return this.call(new List<Object>());
-  }
-
-  public Object call(Object param) {
-    return this.call(new List<Object>{ param });
-  }
-
   public Object call(List<Object> params) {
     this.callCount++;
     this.lastCallParams = params;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Rename `hasBeenCalledWith(List)` and `hasBeenCalledWith(Mather)` to `hasBeenCalledWithParams`.
It allows to call with a list of Params
And keep the syntactic sugar hasBeenCalledWith(Object) for single argument methods. It works even if the only element is a list.

It allow to not have to wrap a single list parameter around a list of params.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A usage issue was detected by a CSG colleague
Improve the user experience

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

With a dedicated test class, added in another PR

## Screenshots (if appropriate):
