### PR TITLE
feat: add hasbeenCalledWith and hasBeenLastCalledWith

### DIFF
--- a/force-app/classes/src/Assertions.cls
+++ b/force-app/classes/src/Assertions.cls
@@ -6,10 +6,6 @@
  */
 @IsTest
 public class Assertions {
-  public interface ParametersMatcher {
-    void assertMatches(List<Object> actualParams);
-  }
-
   public virtual class SystemAsserter {
     public virtual void assertEquals(
       Object expected,
@@ -55,6 +51,18 @@ public class Assertions {
       );
     }
 
+    public void hasBeenCalledTimes(final Integer count) {
+      this.asserter.assertEquals(
+        true,
+        this.spy.hasBeenCalledTimes(count),
+        'Method ' +
+        this.spy.methodName +
+        ' was not called ' +
+        count +
+        ' times'
+      );
+    }
+
     public void hasBeenCalledWith(Object params) {
       this.hasBeenCalledWithParams(new List<Object>{ params });
     }
@@ -67,10 +75,55 @@ public class Assertions {
         this.spy.methodName +
         ' was not called'
       );
-      matcher.assertMatches(this.spy.getLastCallParams());
+      this.asserter.assertEquals(
+        true,
+        this.spy.hasBeenCalledWith(matcher),
+        'Method ' +
+        this.spy.methodName +
+        ' was not called with matcher'
+      );
     }
 
     public void hasBeenCalledWithParams(List<Object> params) {
+      this.asserter.assertEquals(
+        true,
+        this.spy.hasBeenCalled(),
+        'Method ' +
+        this.spy.methodName +
+        ' was not called'
+      );
+      this.asserter.assertEquals(
+        true,
+        this.spy.hasBeenCalledWith(params),
+        'Method ' +
+        this.spy.methodName +
+        ' was not called with ' +
+        params
+      );
+    }
+
+    public void hasBeenLastCalledWith(Object params) {
+      this.hasBeenLastCalledWithParams(new List<Object>{ params });
+    }
+
+    public void hasBeenLastCalledWithParams(ParametersMatcher matcher) {
+      this.asserter.assertEquals(
+        false,
+        this.spy.hasBeenCalled(),
+        'Method ' +
+        this.spy.methodName +
+        ' was not last called'
+      );
+      this.asserter.assertEquals(
+        true,
+        this.spy.hasBeenLastCalledWith(matcher),
+        'Method ' +
+        this.spy.methodName +
+        ' was not last called with matcher'
+      );
+    }
+
+    public void hasBeenLastCalledWithParams(List<Object> params) {
       this.asserter.assertEquals(
         true,
         this.spy.hasBeenCalled(),
@@ -83,7 +136,8 @@ public class Assertions {
         this.spy.getLastCallParams(),
         'Method ' +
         this.spy.methodName +
-        ' was not called'
+        ' was not last called with ' +
+        params
       );
     }
   }

--- a/force-app/classes/src/Assertions.cls
+++ b/force-app/classes/src/Assertions.cls
@@ -132,8 +132,8 @@ public class Assertions {
         ' was not called'
       );
       this.asserter.assertEquals(
-        params,
-        this.spy.getLastCallParams(),
+        true,
+        this.spy.hasBeenLastCalledWith(params),
         'Method ' +
         this.spy.methodName +
         ' was not last called with ' +

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -18,8 +18,7 @@
 @IsTest
 public class MethodSpy {
   public String methodName;
-  private Integer callCount = 0;
-  private List<Object> lastCallParams;
+  private List<List<Object>> callParams;
   private List<ParameterizedMethodSpyCall> parameterizedMethodCalls = new List<ParameterizedMethodSpyCall>();
   private Object returnValue;
   private Boolean configuredGlobalReturn = false;
@@ -27,23 +26,39 @@ public class MethodSpy {
 
   public MethodSpy(String methodName) {
     this.methodName = methodName;
+    this.callParams = new List<List<Object>>();
   }
 
   public List<Object> getLastCallParams() {
-    return this.lastCallParams;
+    return this.hasBeenCalled()
+      ? this.callParams[this.callParams.size() - 1]
+      : null;
   }
 
   public Boolean hasBeenCalled() {
-    return this.callCount > 0;
+    return !this.callParams.isEmpty();
+  }
+
+  public Boolean hasBeenCalledWith(List<Object> params) {
+    for (List<Object> callParam : this.callParams) {
+      if (callParam == params) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  public Boolean hasBeenLastCalledWith(List<Object> params) {
+    return this.getLastCallParams() == params;
   }
 
   public Boolean hasBeenCalledTimes(final Integer count) {
-    return this.callCount == count;
+    return this.callParams.size() == count;
   }
 
   public Object call(List<Object> params) {
-    this.callCount++;
-    this.lastCallParams = params;
+    this.callParams.add(params);
 
     if (
       this.parameterizedMethodCalls.isEmpty() &&

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -18,7 +18,7 @@
 @IsTest
 public class MethodSpy {
   public String methodName;
-  private List<List<Object>> callParams; //TODO create encapsulating object (calllog, with callparameter type)
+  private CallLog callLog;
   private List<ParameterizedMethodSpyCall> parameterizedMethodCalls = new List<ParameterizedMethodSpyCall>();
   private Object returnValue;
   private Boolean configuredGlobalReturn = false;
@@ -26,26 +26,17 @@ public class MethodSpy {
 
   public MethodSpy(String methodName) {
     this.methodName = methodName;
-    this.callParams = new List<List<Object>>();
-  }
-
-  public List<List<Object>> getCallParams() {
-    return this.callParams;
-  }
-
-  public List<Object> getLastCallParams() {
-    return this.hasBeenCalled()
-      ? this.callParams[this.callParams.size() - 1]
-      : null;
+    this.callLog = new CallLog();
   }
 
   public Boolean hasBeenCalled() {
-    return !this.callParams.isEmpty();
+    return !this.callLog.isEmpty();
   }
 
   public Boolean hasBeenCalledWith(List<Object> params) {
-    for (List<Object> callParam : this.callParams) {
-      if (callParam == params) {
+    Iterator<CallParameter> it = this.callLog.iterator();
+    while (it.hasNext()) {
+      if (params == it.next().params) {
         return true;
       }
     }
@@ -54,8 +45,9 @@ public class MethodSpy {
   }
 
   public Boolean hasBeenCalledWith(ParametersMatcher matcher) {
-    for (List<Object> callParam : this.callParams) {
-      if (matcher.matches(callParam)) {
+    Iterator<CallParameter> it = this.callLog.iterator();
+    while (it.hasNext()) {
+      if (matcher.matches(it.next().params)) {
         return true;
       }
     }
@@ -64,19 +56,25 @@ public class MethodSpy {
   }
 
   public Boolean hasBeenLastCalledWith(List<Object> params) {
-    return this.getLastCallParams() == params;
+    if (this.callLog.isEmpty()) {
+      return false;
+    }
+    return this.callLog.getLast() == params;
   }
 
   public Boolean hasBeenLastCalledWith(ParametersMatcher matcher) {
-    return matcher.matches(this.getLastCallParams());
+    if (this.callLog.isEmpty()) {
+      return false;
+    }
+    return matcher.matches(this.callLog.getLast());
   }
 
   public Boolean hasBeenCalledTimes(final Integer count) {
-    return this.callParams.size() == count;
+    return this.callLog.size() == count;
   }
 
   public Object call(List<Object> params) {
-    this.callParams.add(params);
+    this.callLog.add(new CallParameter(params));
 
     if (
       this.parameterizedMethodCalls.isEmpty() &&
@@ -129,5 +127,41 @@ public class MethodSpy {
     );
     this.parameterizedMethodCalls.add(parameterizedMethodCall);
     return parameterizedMethodCall;
+  }
+
+  private class CallLog implements Iterable<CallParameter> {
+    private List<CallParameter> callParams = new List<CallParameter>();
+
+    public void add(CallParameter callParam) {
+      this.callParams.add(callParam);
+    }
+
+    public Boolean isEmpty() {
+      return this.callParams.isEmpty();
+    }
+
+    public Integer size() {
+      return this.callParams.size();
+    }
+
+    public List<Object> get(final Integer index) {
+      return this.callParams[index].params;
+    }
+
+    public List<Object> getLast() {
+      return this.callParams[this.size() - 1].params;
+    }
+
+    public Iterator<CallParameter> iterator() {
+      return this.callParams.iterator();
+    }
+  }
+
+  private class CallParameter {
+    public List<Object> params { get; private set; }
+
+    public CallParameter(final List<Object> params) {
+      this.params = params;
+    }
   }
 }

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -29,6 +29,10 @@ public class MethodSpy {
     this.callParams = new List<List<Object>>();
   }
 
+  public List<List<Object>> getCallParams() {
+    return this.callParams;
+  }
+
   public List<Object> getLastCallParams() {
     return this.hasBeenCalled()
       ? this.callParams[this.callParams.size() - 1]

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -18,7 +18,7 @@
 @IsTest
 public class MethodSpy {
   public String methodName;
-  private List<List<Object>> callParams;
+  private List<List<Object>> callParams; //TODO create encapsulating object (calllog, with callparameter type)
   private List<ParameterizedMethodSpyCall> parameterizedMethodCalls = new List<ParameterizedMethodSpyCall>();
   private Object returnValue;
   private Boolean configuredGlobalReturn = false;
@@ -53,8 +53,22 @@ public class MethodSpy {
     return false;
   }
 
+  public Boolean hasBeenCalledWith(ParametersMatcher matcher) {
+    for (List<Object> callParam : this.callParams) {
+      if (matcher.matches(callParam)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   public Boolean hasBeenLastCalledWith(List<Object> params) {
     return this.getLastCallParams() == params;
+  }
+
+  public Boolean hasBeenLastCalledWith(ParametersMatcher matcher) {
+    return matcher.matches(this.getLastCallParams());
   }
 
   public Boolean hasBeenCalledTimes(final Integer count) {

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -34,18 +34,11 @@ public class MethodSpy {
   }
 
   public Boolean hasBeenCalledWith(List<Object> params) {
-    Iterator<CallParameter> it = this.callLog.iterator();
-    while (it.hasNext()) {
-      if (params == it.next().params) {
-        return true;
-      }
-    }
-
-    return false;
+    return this.hasBeenCalledWith(new EqualsMatcher(params));
   }
 
   public Boolean hasBeenCalledWith(ParametersMatcher matcher) {
-    Iterator<CallParameter> it = this.callLog.iterator();
+    Iterator<MethodCall> it = this.callLog.iterator();
     while (it.hasNext()) {
       if (matcher.matches(it.next().params)) {
         return true;
@@ -56,10 +49,7 @@ public class MethodSpy {
   }
 
   public Boolean hasBeenLastCalledWith(List<Object> params) {
-    if (this.callLog.isEmpty()) {
-      return false;
-    }
-    return this.callLog.getLast() == params;
+    return this.hasBeenLastCalledWith(new EqualsMatcher(params));
   }
 
   public Boolean hasBeenLastCalledWith(ParametersMatcher matcher) {
@@ -74,7 +64,7 @@ public class MethodSpy {
   }
 
   public Object call(List<Object> params) {
-    this.callLog.add(new CallParameter(params));
+    this.callLog.add(new MethodCall(params));
 
     if (
       this.parameterizedMethodCalls.isEmpty() &&
@@ -129,10 +119,10 @@ public class MethodSpy {
     return parameterizedMethodCall;
   }
 
-  private class CallLog implements Iterable<CallParameter> {
-    private List<CallParameter> callParams = new List<CallParameter>();
+  private class CallLog implements Iterable<MethodCall> {
+    private List<MethodCall> callParams = new List<MethodCall>();
 
-    public void add(CallParameter callParam) {
+    public void add(MethodCall callParam) {
       this.callParams.add(callParam);
     }
 
@@ -152,16 +142,28 @@ public class MethodSpy {
       return this.callParams[this.size() - 1].params;
     }
 
-    public Iterator<CallParameter> iterator() {
+    public Iterator<MethodCall> iterator() {
       return this.callParams.iterator();
     }
   }
 
-  private class CallParameter {
+  private class MethodCall {
     public List<Object> params { get; private set; }
 
-    public CallParameter(final List<Object> params) {
+    public MethodCall(final List<Object> params) {
       this.params = params;
+    }
+  }
+
+  private class EqualsMatcher implements ParametersMatcher {
+    private List<Object> paramsToMatch;
+
+    public EqualsMatcher(final List<Object> paramsToMatch) {
+      this.paramsToMatch = paramsToMatch;
+    }
+
+    public Boolean matches(List<Object> params) {
+      return this.paramsToMatch == params;
     }
   }
 }

--- a/force-app/classes/src/ParametersMatcher.cls
+++ b/force-app/classes/src/ParametersMatcher.cls
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+public interface ParametersMatcher {
+  Boolean matches(List<Object> actualParams);
+}

--- a/force-app/classes/src/ParametersMatcher.cls-meta.xml
+++ b/force-app/classes/src/ParametersMatcher.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/classes/test/AssertionsTest.cls
+++ b/force-app/classes/test/AssertionsTest.cls
@@ -82,14 +82,8 @@ private class AssertionsTest {
 
     // Assert
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
-    System.assertEquals(
-      new List<Object>{ param },
-      fakeAsserter.assertEqualsLastExpected
-    );
-    System.assertEquals(
-      spy.getLastCallParams(),
-      fakeAsserter.assertEqualsLastActual
-    );
+    System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
+    System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
   }
 
   @isTest
@@ -107,14 +101,8 @@ private class AssertionsTest {
 
     // Assert
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
-    System.assertEquals(
-      new List<Object>{ null },
-      fakeAsserter.assertEqualsLastExpected
-    );
-    System.assertEquals(
-      spy.getLastCallParams(),
-      fakeAsserter.assertEqualsLastActual
-    );
+    System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
+    System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
   }
 
   @isTest
@@ -133,11 +121,8 @@ private class AssertionsTest {
 
     // Assert
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
-    System.assertEquals(param, fakeAsserter.assertEqualsLastExpected);
-    System.assertEquals(
-      spy.getLastCallParams(),
-      fakeAsserter.assertEqualsLastActual
-    );
+    System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
+    System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
   }
 
   @isTest
@@ -156,11 +141,8 @@ private class AssertionsTest {
 
     // Assert
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
-    System.assertEquals(null, fakeAsserter.assertEqualsLastExpected);
-    System.assertEquals(
-      spy.getLastCallParams(),
-      fakeAsserter.assertEqualsLastActual
-    );
+    System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
+    System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
   }
 
   @isTest
@@ -175,7 +157,7 @@ private class AssertionsTest {
     );
     final List<Object> spyCallParam = new List<Object>{ 'param' };
     spy.call(spyCallParam);
-    final ParametersMatcherStub param = new ParametersMatcherStub(fakeAsserter);
+    final ParametersMatcherStub param = new ParametersMatcherStub();
     param.expected = spyCallParam;
 
     // Act
@@ -183,11 +165,8 @@ private class AssertionsTest {
 
     // Assert
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
-    System.assertEquals(spyCallParam, fakeAsserter.assertEqualsLastExpected);
-    System.assertEquals(
-      spy.getLastCallParams(),
-      fakeAsserter.assertEqualsLastActual
-    );
+    System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
+    System.assertEquals(true, fakeAsserter.assertEqualsLastActual);
   }
 
   @isTest
@@ -199,16 +178,16 @@ private class AssertionsTest {
       spy,
       fakeAsserter
     );
-    final Assertions.ParametersMatcher param = null;
+    final ParametersMatcher param = null;
+    spy.call(new List<Object>());
 
     // Act
     try {
-      sut.hasBeenCalledWithParams(param);
+      sut.hasBeenCalledWithParams((ParametersMatcher) param);
 
       // Assert
       System.assert(false); // Should not reach this point
     } catch (Exception ex) {
-      System.assertEquals(1, fakeAsserter.assertEqualsCallCount);
       System.assertEquals(false, fakeAsserter.assertEqualsLastExpected);
       System.assertEquals(
         spy.hasBeenCalled(),
@@ -218,16 +197,38 @@ private class AssertionsTest {
     }
   }
 
-  class ParametersMatcherStub implements Assertions.ParametersMatcher {
-    private FakeAsserter asserter;
-    public Object expected;
+  @isTest
+  static void givenNullParametersMatcher_hasBeenLastCalledWithParams_callsAssertEquals() {
+    // Arrange
+    final MethodSpy spy = new MethodSpy('method');
+    final FakeAsserter fakeAsserter = new FakeAsserter();
+    final Assertions.MethodSpyAssert sut = new Assertions.MethodSpyAssert(
+      spy,
+      fakeAsserter
+    );
+    final ParametersMatcher param = null;
 
-    public ParametersMatcherStub(final FakeAsserter asserter) {
-      this.asserter = asserter;
+    // Act
+    try {
+      sut.hasBeenLastCalledWithParams((ParametersMatcher) param);
+
+      // Assert
+      System.assert(false); // Should not reach this point
+    } catch (Exception ex) {
+      System.assertEquals(false, fakeAsserter.assertEqualsLastExpected);
+      System.assertEquals(
+        spy.hasBeenCalled(),
+        fakeAsserter.assertEqualsLastActual
+      );
+      System.assert(ex instanceof NullPointerException);
     }
+  }
 
-    public void assertMatches(List<Object> params) {
-      this.asserter.assertEquals(this.expected, params, 'message not spied');
+  class ParametersMatcherStub implements ParametersMatcher {
+    public List<Object> expected;
+
+    public boolean matches(List<Object> params) {
+      return this.expected == params;
     }
   }
 

--- a/force-app/classes/test/AssertionsTest.cls
+++ b/force-app/classes/test/AssertionsTest.cls
@@ -207,6 +207,7 @@ private class AssertionsTest {
       fakeAsserter
     );
     final ParametersMatcher param = null;
+    spy.call(null);
 
     // Act
     try {

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -358,6 +358,23 @@ private class MethodSpyTest {
   }
 
   @IsTest
+  static void givenSpy_getCallParam_returnParamList() {
+    // Arrange
+    List<Object> first = new List<Object>{ new Opportunity() };
+    List<Object> last = new List<Object>{ new Account() };
+    final MethodSpy sut = new MethodSpy('methodName');
+    System.assert(sut.getCallParams().isEmpty());
+
+    // Act && Assert
+    sut.call(first);
+    System.assert(sut.getCallParams().size() == 1);
+    System.assert(sut.getCallParams()[0] == first);
+    sut.call(last);
+    System.assert(sut.getCallParams().size() == 2);
+    System.assert(sut.getCallParams()[1] == last);
+  }
+
+  @IsTest
   static void e2e_returns_then_whenCalledWith() {
     // Arrange
     final MethodSpy sut = new MethodSpy('methodName');

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -329,6 +329,35 @@ private class MethodSpyTest {
   }
 
   @IsTest
+  static void givenSpyCalledLastWithParams_hasBeenCalledLastWithParams_returnsTrueForLastAndFalseElse() {
+    // Arrange
+    List<Object> first = new List<Object>{ new Opportunity() };
+    List<Object> last = new List<Object>{ new Account() };
+    final MethodSpy sut = new MethodSpy('methodName');
+    sut.call(first);
+    sut.call(last);
+
+    // Act && Assert
+    System.assert(!sut.hasBeenLastCalledWith(first));
+    System.assert(sut.hasBeenLastCalledWith(last));
+  }
+
+  @IsTest
+  static void givenSpyCalledMultipleTimes_hasBeenCalledWith_returnsTrueForCalledParamsElseFalse() {
+    // Arrange
+    List<Object> first = new List<Object>{ new Opportunity() };
+    List<Object> last = new List<Object>{ new Account() };
+    final MethodSpy sut = new MethodSpy('methodName');
+    sut.call(first);
+    sut.call(last);
+
+    // Act && Assert
+    System.assert(sut.hasBeenCalledWith(first));
+    System.assert(sut.hasBeenCalledWith(last));
+    System.assert(!sut.hasBeenCalledWith(new List<Object>{ new Case() }));
+  }
+
+  @IsTest
   static void e2e_returns_then_whenCalledWith() {
     // Arrange
     final MethodSpy sut = new MethodSpy('methodName');

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -329,7 +329,7 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyCalledLastWithParams_hasBeenCalledLastWithParams_returnsTrueForLastAndFalseElse() {
+  static void givenSpyCalledLastWithParams_hasBeenLastCalledWithParams_returnsTrueForLastAndFalseElse() {
     // Arrange
     List<Object> first = new List<Object>{ new Opportunity() };
     List<Object> last = new List<Object>{ new Account() };
@@ -355,6 +355,34 @@ private class MethodSpyTest {
     System.assert(sut.hasBeenCalledWith(first));
     System.assert(sut.hasBeenCalledWith(last));
     System.assert(!sut.hasBeenCalledWith(new List<Object>{ new Case() }));
+  }
+
+  @IsTest
+  static void givenSpyCalledLastWithParams_hasBeenLastCalledWithMatcher_returnsMatches() {
+    // Arrange
+    List<Object> param = new List<Object>();
+    final MethodSpy sut = new MethodSpy('methodName');
+    ParametersMatcherStub stub = new ParametersMatcherStub();
+    stub.expected = param;
+
+    // Act & Assert
+    System.assert(!sut.hasBeenLastCalledWith(stub));
+    sut.call(param);
+    System.assert(sut.hasBeenLastCalledWith(stub));
+  }
+
+  @IsTest
+  static void givenSpyCalledLastWithParams_hasBeenCalledWithMatcher_returnsMatches() {
+    // Arrange
+    List<Object> param = new List<Object>();
+    final MethodSpy sut = new MethodSpy('methodName');
+    ParametersMatcherStub stub = new ParametersMatcherStub();
+    stub.expected = param;
+
+    // Act & Assert
+    System.assert(!sut.hasBeenCalledWith(stub));
+    sut.call(param);
+    System.assert(sut.hasBeenCalledWith(stub));
   }
 
   @IsTest
@@ -505,6 +533,14 @@ private class MethodSpyTest {
       System.assert(false, 'test should have throw an exception');
     } catch (Exception e) {
       System.assertEquals(expectedException.getMessage(), e.getMessage());
+    }
+  }
+
+  class ParametersMatcherStub implements ParametersMatcher {
+    public List<Object> expected;
+
+    public boolean matches(List<Object> params) {
+      return this.expected == params;
     }
   }
 

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -215,47 +215,6 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyCalledWithEmptyParamList_whenGetLastCallParams_itReturnsTheSameParamsList() {
-    // Arrange
-    final MethodSpy sut = new MethodSpy('methodName');
-    sut.returns('any result');
-    sut.call(new List<Object>{ 'param1' });
-
-    // Act
-    final Object result = sut.getlastCallParams();
-
-    // Assert
-    System.assertEquals(new List<Object>{ 'param1' }, result);
-  }
-
-  @IsTest
-  static void givenSpyCalledWithNoParams_whenGetLastCallParams_itReturnsNull() {
-    // Arrange
-    final MethodSpy sut = new MethodSpy('methodName');
-    sut.returns('any result');
-    sut.call(null);
-
-    // Act
-    final Object result = sut.getlastCallParams();
-
-    // Assert
-    System.assertEquals(null, result);
-  }
-
-  @IsTest
-  static void givenSpyNotCalled_whenGetLastCallParams_itReturnsNull() {
-    // Arrange
-    final MethodSpy sut = new MethodSpy('methodName');
-    sut.returns('any result');
-
-    // Act
-    final Object result = sut.getlastCallParams();
-
-    // Assert
-    System.assertEquals(null, result);
-  }
-
-  @IsTest
   static void givenSpyNotCalled_hasBeenCalled_itReturnsFalse() {
     // Arrange
     final MethodSpy sut = new MethodSpy('methodName');
@@ -383,23 +342,6 @@ private class MethodSpyTest {
     System.assert(!sut.hasBeenCalledWith(stub));
     sut.call(param);
     System.assert(sut.hasBeenCalledWith(stub));
-  }
-
-  @IsTest
-  static void givenSpy_getCallParam_returnParamList() {
-    // Arrange
-    List<Object> first = new List<Object>{ new Opportunity() };
-    List<Object> last = new List<Object>{ new Account() };
-    final MethodSpy sut = new MethodSpy('methodName');
-    System.assert(sut.getCallParams().isEmpty());
-
-    // Act && Assert
-    sut.call(first);
-    System.assert(sut.getCallParams().size() == 1);
-    System.assert(sut.getCallParams()[0] == first);
-    sut.call(last);
-    System.assert(sut.getCallParams().size() == 2);
-    System.assert(sut.getCallParams()[1] == last);
   }
 
   @IsTest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add `hasBeenCalledWith` and `hasBeenLastCalledWIth` to that we can assert on spy calls.
It removes the `getCallParams` and `getLastCallParams` helper methods and simplify a bit the API

## Motivation and Context

Having a better API

## How Has This Been Tested?

Apex unit test (`MethodSpyTest`) and integration test  (`AssertionsTest`)
