### PR TITLE
feat: implement whenCalledWithParams using ParameterMatcher

### DIFF
--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -116,8 +116,12 @@ public class MethodSpy {
   }
 
   public MethodSpyCall whenCalledWithParams(List<Object> params) {
+    return whenCalledWithParams(new DeepEqualsListMatcher(params));
+  }
+
+  public MethodSpyCall whenCalledWithParams(ParametersMatcher matcher) {
     final ParameterizedMethodSpyCall parameterizedMethodCall = new ParameterizedMethodSpyCall(
-      params
+      matcher
     );
     this.parameterizedMethodCalls.add(parameterizedMethodCall);
     return parameterizedMethodCall;
@@ -171,18 +175,40 @@ public class MethodSpy {
     }
   }
 
+  private class DeepEqualsListMatcher implements ParametersMatcher {
+    private List<Object> paramsToMatch;
+
+    public DeepEqualsListMatcher(final List<Object> paramsToMatch) {
+      this.paramsToMatch = paramsToMatch;
+    }
+
+    public Boolean matches(List<Object> params) {
+      if (this.paramsToMatch.size() != params.size()) {
+        return false;
+      }
+      for (Integer i = 0; i < params.size(); i++) {
+        Object expectedParam = this.paramsToMatch.get(i);
+        Object actualParam = params.get(i);
+        if (actualParam != expectedParam) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
   public interface MethodSpyCall {
     void thenReturn(Object value);
     void thenThrow(Exception error);
   }
 
   private class ParameterizedMethodSpyCall implements MethodSpyCall {
-    private List<Object> params;
+    private ParametersMatcher matcher;
     public Object value { get; private set; }
     public Exception error { get; private set; }
 
-    public ParameterizedMethodSpyCall(List<Object> params) {
-      this.params = params;
+    public ParameterizedMethodSpyCall(ParametersMatcher matcher) {
+      this.matcher = matcher;
     }
 
     public void thenReturn(Object value) {
@@ -198,17 +224,7 @@ public class MethodSpy {
     }
 
     public boolean matches(List<Object> params) {
-      if (this.params.size() != params.size()) {
-        return false;
-      }
-      for (Integer i = 0; i < params.size(); i++) {
-        Object expectedParam = this.params.get(i);
-        Object actualParam = params.get(i);
-        if (actualParam != expectedParam) {
-          return false;
-        }
-      }
-      return true;
+      return this.matcher.matches(params);
     }
   }
 }

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -157,6 +157,30 @@ private class MethodSpyTest {
     // Assert
     System.assertEquals('Expected Result', result);
   }
+
+  @IsTest
+  static void givenSpyConfiguredOnceToReturnOnMatchingTypeMatcher_whenCallingTheSpyWithWWrong_itShouldThrowIllegalArgumentException() {
+    // Arrange
+    final MethodSpy sut = new MethodSpy('methodName');
+    sut.whenCalledWithParams(new SObjectTypeMatcher(Account.getSObjectType()))
+      .thenReturn('Expected Result');
+
+    // Act
+    try {
+      final Object result = sut.call(
+        new List<Object>{ new Opportunity(), true }
+      );
+      // Assert
+      System.assert(false, 'test should have throw an exception');
+    } catch (Exception ex) {
+      System.assert(
+        ex instanceof IllegalArgumentException,
+        'Exception should be IllegalArgumentException'
+      );
+    }
+  }
+
+  @IsTest
   static void givenSpyConfiguredMultipleTimesToReturnOnMatchingParams_whenCallingTheSpy_itReturnsTheConfiguredValue() {
     // Arrange
     final MethodSpy sut = new MethodSpy('methodName');

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -145,6 +145,18 @@ private class MethodSpyTest {
   }
 
   @IsTest
+  static void givenSpyConfiguredOnceToReturnOnMatchingTypeMatcher_whenCallingTheSpyWithRightType_itReturnsTheConfiguredValue() {
+    // Arrange
+    final MethodSpy sut = new MethodSpy('methodName');
+    sut.whenCalledWithParams(new SObjectTypeMatcher(Account.getSObjectType()))
+      .thenReturn('Expected Result');
+
+    // Act
+    final Object result = sut.call(new List<Object>{ new Account(), true });
+
+    // Assert
+    System.assertEquals('Expected Result', result);
+  }
   static void givenSpyConfiguredMultipleTimesToReturnOnMatchingParams_whenCallingTheSpy_itReturnsTheConfiguredValue() {
     // Arrange
     final MethodSpy sut = new MethodSpy('methodName');
@@ -602,6 +614,19 @@ private class MethodSpyTest {
 
     public boolean matches(List<Object> params) {
       return this.expected == params;
+    }
+  }
+
+  class SObjectTypeMatcher implements ParametersMatcher {
+    private SObjectType matchingType;
+
+    public SObjectTypeMatcher(SObjectType matchingType) {
+      this.matchingType = matchingType;
+    }
+
+    public boolean matches(List<Object> params) {
+      SObject param0 = (SObject) params[0];
+      return this.matchingType == param0.getsObjectType();
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add `public MethodSpyCall whenCalledWithParams(ParametersMatcher matcher)` method to allow to write:
```java
final MethodSpy sut = new MethodSpy('methodName');
    sut.whenCalledWithParams(new MyMatcher())
      // Returns or Throw 
```

Refactor current implementation to use this new method with a deep list equal matcher internally

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improve Developer Experience

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit Tests
Functional Test are coming in a new branch using it
