### PR TITLE
feat: enhance assertion error messages by including call history

### DIFF
--- a/force-app/classes/src/Assertions.cls
+++ b/force-app/classes/src/Assertions.cls
@@ -35,9 +35,7 @@ public class Assertions {
       this.asserter.assertEquals(
         false,
         this.spy.hasBeenCalled(),
-        'Method ' +
-        this.spy.methodName +
-        ' was called'
+        buildErrorMessage(this.spy, ErrorMessageType.CALLED)
       );
     }
 
@@ -45,9 +43,7 @@ public class Assertions {
       this.asserter.assertEquals(
         true,
         this.spy.hasBeenCalled(),
-        'Method ' +
-        this.spy.methodName +
-        ' was not called'
+        buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED)
       );
     }
 
@@ -55,11 +51,7 @@ public class Assertions {
       this.asserter.assertEquals(
         true,
         this.spy.hasBeenCalledTimes(count),
-        'Method ' +
-        this.spy.methodName +
-        ' was not called ' +
-        count +
-        ' times'
+        buildErrorMessage(this.spy, ErrorMessageType.NOT_CALLED_TIMES, count)
       );
     }
 
@@ -67,17 +59,12 @@ public class Assertions {
       this.asserter.assertEquals(
         true,
         this.spy.hasBeenCalled(),
-        'Method ' +
-        this.spy.methodName +
-        ' was not called'
+        buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED)
       );
       this.asserter.assertEquals(
         true,
         this.spy.hasBeenCalledWith(params),
-        'Method ' +
-        this.spy.methodName +
-        ' was not called with ' +
-        params
+        buildErrorMessage(this.spy, ErrorMessageType.NOT_CALLED_WITH, params)
       );
     }
 
@@ -85,22 +72,126 @@ public class Assertions {
       this.asserter.assertEquals(
         true,
         this.spy.hasBeenCalled(),
-        'Method ' +
-        this.spy.methodName +
-        ' was not called'
+        buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED)
       );
       this.asserter.assertEquals(
         true,
         this.spy.hasBeenLastCalledWith(params),
-        'Method ' +
-        this.spy.methodName +
-        ' was not last called with ' +
-        params
+        buildErrorMessage(
+          this.spy,
+          ErrorMessageType.NOT_LAST_CALLED_WITH,
+          params
+        )
       );
     }
   }
 
   public static MethodSpyAssert assertThat(MethodSpy spy) {
     return new MethodSpyAssert(spy);
+  }
+
+  private enum ErrorMessageType {
+    CALLED,
+    NEVER_CALLED,
+    NOT_CALLED_WITH,
+    NOT_LAST_CALLED_WITH,
+    NOT_CALLED_TIMES
+  }
+
+  private class ErrorMessageRow {
+    protected String message;
+    protected Boolean tabbed;
+
+    ErrorMessageRow(String message) {
+      this(message, false);
+    }
+    ErrorMessageRow(String message, Boolean tabbed) {
+      this.message = message;
+      this.tabbed = tabbed;
+    }
+  }
+
+  private class ErrorMessage {
+    private String headline;
+    private List<ErrorMessageRow> callTraces;
+    ErrorMessage(MethodSpy spy, ErrorMessageType error) {
+      this(spy, error, null);
+    }
+    ErrorMessage(MethodSpy spy, ErrorMessageType error, Object argument) {
+      this.headline = this.buildHeadline(spy, error, argument);
+      this.callTraces = this.buildCallTraces(spy);
+    }
+
+    private String buildHeadline(
+      MethodSpy spy,
+      ErrorMessageType error,
+      Object argument
+    ) {
+      final Map<ErrorMessageType, String> messages = new Map<ErrorMessageType, String>{
+        ErrorMessageType.CALLED => 'Method {0} was called',
+        ErrorMessageType.NEVER_CALLED => 'Method {0} was not called',
+        ErrorMessageType.NOT_CALLED_WITH => 'Method {0} was not called with {1}',
+        ErrorMessageType.NOT_LAST_CALLED_WITH => 'Method {0} was not last called with {1}',
+        ErrorMessageType.NOT_CALLED_TIMES => 'Method {0} was not called {1} times'
+      };
+      return String.format(
+        messages.get(error),
+        new List<String>{ spy.methodName, argument + '' }
+      );
+    }
+
+    private List<ErrorMessageRow> buildCallTraces(MethodSpy spy) {
+      final List<Params> callLogParams = spy.getCallLogParams();
+      if (callLogParams.isEmpty()) {
+        return new List<ErrorMessageRow>();
+      }
+
+      final List<ErrorMessageRow> rows = new List<ErrorMessageRow>();
+      rows.add(new ErrorMessageRow('method call history:'));
+      final String template = '#{0} {1}({2})';
+      for (Integer i = 0; i < callLogParams.size(); i++) {
+        final Params params = callLogParams[i];
+        final Integer count = callLogParams.size() - i;
+        rows.add(
+          new ErrorMessageRow(
+            String.format(
+              template,
+              new List<Object>{ count, spy.methodName, params }
+            ),
+            true
+          )
+        );
+      }
+      return rows;
+    }
+
+    override public String toString() {
+      final List<String> lines = new List<String>();
+      lines.add(this.headline);
+      if (!callTraces.isEmpty()) {
+        for (ErrorMessageRow row : callTraces) {
+          final String prefix = row.tabbed ? '\t' : '';
+          final String line = prefix + row.message;
+          lines.add(line);
+        }
+        lines.add('');
+      }
+      return String.join(lines, '\n');
+    }
+  }
+
+  private static String buildErrorMessage(
+    MethodSpy spy,
+    ErrorMessageType error
+  ) {
+    return new ErrorMessage(spy, error, null).toString();
+  }
+
+  private static String buildErrorMessage(
+    MethodSpy spy,
+    ErrorMessageType error,
+    Object argument
+  ) {
+    return new ErrorMessage(spy, error, argument).toString();
   }
 }

--- a/force-app/classes/src/Matcher.cls
+++ b/force-app/classes/src/Matcher.cls
@@ -37,6 +37,10 @@ public class Matcher {
     public Boolean matches(final Object callArgument) {
       return true;
     }
+
+    override public String toString() {
+      return 'any';
+    }
   }
 
   private class EqualsMatcher implements ArgumentMatcher {
@@ -49,17 +53,27 @@ public class Matcher {
     public Boolean matches(final Object callArgument) {
       return callArgument == this.callArgumentToMatch;
     }
+
+    override public String toString() {
+      return callArgumentToMatch + '';
+    }
   }
 
   private class JSONMatcher implements ArgumentMatcher {
-    private String callArgumentToMatch;
+    private Object callArgumentToMatch;
+    private String jsonValue;
 
     public JSONMatcher(final Object callArgumentToMatch) {
-      this.callArgumentToMatch = JSON.serialize(callArgumentToMatch);
+      this.callArgumentToMatch = callArgumentToMatch;
+      this.jsonValue = JSON.serialize(callArgumentToMatch);
     }
 
     public boolean matches(final Object callArgument) {
-      return this.callArgumentToMatch == JSON.serialize(callArgument);
+      return this.jsonValue == JSON.serialize(callArgument);
+    }
+
+    override public String toString() {
+      return 'json(' + callArgumentToMatch + ')';
     }
   }
 
@@ -102,6 +116,10 @@ public class Matcher {
         result = message.substringBefore(' to Date');
       }
       return result;
+    }
+
+    override public String toString() {
+      return callArgumentToMatch + '.Type';
     }
   }
 }

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -135,6 +135,16 @@ public class MethodSpy {
     return parameterizedMethodCall;
   }
 
+  public List<Params> getCallLogParams() {
+    final List<Params> reversedCallsTrace = new List<Params>();
+    final List<MethodCall> calls = this.callLog.callParams;
+    for (Integer i = calls.size() - 1; i >= 0; i--) {
+      final MethodCall call = calls[i];
+      reversedCallsTrace.add(Params.ofList(call.params));
+    }
+    return reversedCallsTrace;
+  }
+
   private class CallLog implements Iterable<MethodCall> {
     private List<MethodCall> callParams = new List<MethodCall>();
 

--- a/force-app/classes/src/Params.cls
+++ b/force-app/classes/src/Params.cls
@@ -20,6 +20,10 @@ public class Params {
     }
   }
 
+  override public String toString() {
+    return '[' + listOfArgs + ']';
+  }
+
   public static Params empty() {
     return new Params();
   }
@@ -71,8 +75,10 @@ public class Params {
 
   public static Params ofList(final List<Object> listOfArgs) {
     final Params params = empty();
-    for (Object callArgument : listOfArgs) {
-      params.add(callArgument);
+    if (listOfArgs != null) {
+      for (Object callArgument : listOfArgs) {
+        params.add(callArgument);
+      }
     }
     return params;
   }

--- a/force-app/classes/test/AssertionsTest.cls
+++ b/force-app/classes/test/AssertionsTest.cls
@@ -39,6 +39,10 @@ private class AssertionsTest {
     System.assertEquals(1, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(false, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was called',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -58,6 +62,10 @@ private class AssertionsTest {
     System.assertEquals(1, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not called',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -77,6 +85,10 @@ private class AssertionsTest {
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not called with [(Account:{})]',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -98,6 +110,10 @@ private class AssertionsTest {
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not called with [(Account:{}, Opportunity:{})]',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -117,6 +133,10 @@ private class AssertionsTest {
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not called with [(Account:{}, test)]',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -136,6 +156,10 @@ private class AssertionsTest {
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not called with [()]',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -195,6 +219,10 @@ private class AssertionsTest {
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not last called with null',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -214,6 +242,10 @@ private class AssertionsTest {
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not last called with [(Account:{})]',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -233,6 +265,10 @@ private class AssertionsTest {
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not last called with [(Account:{}, test)]',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -252,6 +288,10 @@ private class AssertionsTest {
     System.assertEquals(2, fakeAsserter.assertEqualsCallCount);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not last called with [(null)]',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -318,10 +358,18 @@ private class AssertionsTest {
     sut.hasBeenCalledTimes(0);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not called 0 times\nmethod call history:\n\t#1 method([()])\n',
+      fakeAsserter.assertEqualsLastMessage
+    );
 
     sut.hasBeenCalledTimes(2);
     System.assertEquals(true, fakeAsserter.assertEqualsLastExpected);
     System.assertEquals(false, fakeAsserter.assertEqualsLastActual);
+    System.assertEquals(
+      'Method method was not called 2 times\nmethod call history:\n\t#1 method([()])\n',
+      fakeAsserter.assertEqualsLastMessage
+    );
   }
 
   @isTest
@@ -340,6 +388,7 @@ private class AssertionsTest {
     public Integer assertEqualsCallCount = 0;
     public Object assertEqualsLastExpected;
     public Object assertEqualsLastActual;
+    public String assertEqualsLastMessage;
 
     public override void assertEquals(
       Object expected,
@@ -349,6 +398,7 @@ private class AssertionsTest {
       this.assertEqualsCallCount++;
       this.assertEqualsLastExpected = expected;
       this.assertEqualsLastActual = actual;
+      this.assertEqualsLastMessage = message;
     }
   }
 }

--- a/force-app/classes/test/ParamsTest.cls
+++ b/force-app/classes/test/ParamsTest.cls
@@ -90,7 +90,7 @@ private class ParamsTest {
   }
 
   @isTest
-  static void givenListOf10MixType_whenOfIsCalledWithList_listOfArgsContains10Elements() {
+  static void givenListOf10MixType_whenOfListIsCalledWithList_listOfArgsContains10Elements() {
     // Arrange
     Params sut;
 
@@ -113,6 +113,15 @@ private class ParamsTest {
     // Assert
     System.assertEquals(10, sut.listOfArgs.size());
     assertListOfArgsElementsAreArgumentMatcher(sut);
+  }
+
+  @isTest
+  static void whenOfListIsCalledWithNull_listOfArgsIsEmpty() {
+    // Act
+    final Params result = Params.ofList(null);
+
+    // Assert
+    System.assertEquals(0, result.listOfArgs.size());
   }
 
   @isTest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enhance all assertion error messages to include call history logs when applicable.
This uses the default `toString` mechanism available in Apex to serialize `Params` and dynamic values in error messages

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
