### PR TITLE
refactor: migrate matches method into Params class

### DIFF
--- a/force-app/classes/src/ArgumentMatcher.cls
+++ b/force-app/classes/src/ArgumentMatcher.cls
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2022, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
-public interface ArgumentMatcher {
-  Boolean matches(Object callArgument);
-}

--- a/force-app/classes/src/ArgumentMatcher.cls-meta.xml
+++ b/force-app/classes/src/ArgumentMatcher.cls-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
-    <status>Active</status>
-</ApexClass>

--- a/force-app/classes/src/Matcher.cls
+++ b/force-app/classes/src/Matcher.cls
@@ -20,6 +20,9 @@ public class Matcher {
     Boolean matches(Object callArgument);
   }
 
+  public class MatcherException extends Exception {
+  }
+
   private Matcher() {
   }
 
@@ -134,8 +137,5 @@ public class Matcher {
     override public String toString() {
       return callArgumentToMatch + '.Type';
     }
-  }
-
-  public class MatcherException extends Exception {
   }
 }

--- a/force-app/classes/src/Matcher.cls
+++ b/force-app/classes/src/Matcher.cls
@@ -16,6 +16,10 @@
  */
 @IsTest
 public class Matcher {
+  public interface ArgumentMatcher {
+    Boolean matches(Object callArgument);
+  }
+
   private Matcher() {
   }
 

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -38,19 +38,8 @@ public class MethodSpy {
     }
     final Iterator<MethodCall> it = this.callLog.iterator();
     while (it.hasNext()) {
-      final List<Object> actualListOfArgs = it.next().params;
-
-      if (actualListOfArgs.size() == params.listOfArgs.size()) {
-        Boolean match = true;
-        for (Integer i = 0; i < actualListOfArgs.size(); ++i) {
-          if (!params.listOfArgs[i].matches(actualListOfArgs[i])) {
-            match = false;
-            break;
-          }
-        }
-        if (match) {
-          return true;
-        }
+      if (params.matches(it.next().params)) {
+        return true;
       }
     }
 
@@ -66,16 +55,7 @@ public class MethodSpy {
     }
 
     final List<Object> actualListOfArgs = this.callLog.getLast();
-    if (actualListOfArgs.size() != params.listOfArgs.size()) {
-      return false;
-    }
-
-    for (Integer i = 0; i < actualListOfArgs.size(); ++i) {
-      if (!params.listOfArgs[i].matches(actualListOfArgs[i])) {
-        return false;
-      }
-    }
-    return true;
+    return params.matches(actualListOfArgs);
   }
 
   public Boolean hasBeenCalledTimes(final Integer count) {
@@ -180,12 +160,12 @@ public class MethodSpy {
   }
 
   private class ParameterizedMethodSpyCall implements MethodSpyCall {
-    private Params matchers;
+    private Params paramsMatcher;
     public Object value { get; private set; }
     public Exception error { get; private set; }
 
     public ParameterizedMethodSpyCall(final Params paramsMatcher) {
-      this.matchers = paramsMatcher;
+      this.paramsMatcher = paramsMatcher;
     }
 
     public void thenReturn(Object value) {
@@ -201,17 +181,7 @@ public class MethodSpy {
     }
 
     public boolean matches(final List<Object> callArguments) {
-      if (this.matchers.listOfArgs.size() != callArguments.size()) {
-        return false;
-      }
-
-      for (Integer i = 0; i < this.matchers.listOfArgs.size(); ++i) {
-        if (!this.matchers.listOfArgs[i].matches(callArguments[i])) {
-          return false;
-        }
-      }
-
-      return true;
+      return this.paramsMatcher.matches(callArguments);
     }
   }
 

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -184,7 +184,4 @@ public class MethodSpy {
       return this.paramsMatcher.matches(callArguments);
     }
   }
-
-  public class MatcherException extends Exception {
-  }
 }

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -108,7 +108,8 @@ public class MethodSpy {
     return parameterizedMethodCall;
   }
 
-  public List<Params> getCallLogParams() {
+  @TestVisible
+  private List<Params> getCallLogParams() {
     final List<Params> reversedCallsTrace = new List<Params>();
     final List<MethodCall> calls = this.callLog.callParams;
     for (Integer i = calls.size() - 1; i >= 0; i--) {

--- a/force-app/classes/src/Params.cls
+++ b/force-app/classes/src/Params.cls
@@ -6,25 +6,38 @@
  */
 @IsTest
 public class Params {
-  public List<ArgumentMatcher> listOfArgs { get; private set; }
+  private List<Matcher.ArgumentMatcher> listOfArgs;
 
   private Params() {
-    this.listOfArgs = new List<ArgumentMatcher>();
+    this.listOfArgs = new List<Matcher.ArgumentMatcher>();
   }
 
-  private Params(List<Object> callArguments) {
-    final List<ArgumentMatcher> listOfArgs = new List<ArgumentMatcher>();
+  private Params(final List<Object> callArguments) {
+    this();
     for (Object callArgument : callArguments) {
-      if (callArgument instanceof ArgumentMatcher) {
-        listOfArgs.add((ArgumentMatcher) callArgument);
+      if (callArgument instanceof Matcher.ArgumentMatcher) {
+        this.listOfArgs.add((Matcher.ArgumentMatcher) callArgument);
       } else {
-        listOfArgs.add(Matcher.equals(callArgument));
+        this.listOfArgs.add(Matcher.equals(callArgument));
       }
     }
-    this.listOfArgs = listOfArgs;
   }
 
-  override public String toString() {
+  public boolean matches(final List<Object> callArguments) {
+    if (this.listOfArgs.size() != callArguments?.size()) {
+      return false;
+    }
+
+    for (Integer i = 0; i < this.listOfArgs.size(); ++i) {
+      if (!this.listOfArgs[i].matches(callArguments[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public override String toString() {
     return '[' + listOfArgs + ']';
   }
 

--- a/force-app/classes/test/AssertionsTest.cls
+++ b/force-app/classes/test/AssertionsTest.cls
@@ -232,12 +232,12 @@ private class AssertionsTest {
   }
 
   @isTest
-  static void givenNullArgumentMatchers_hasBeenLastCalledWithParams_callsAssertEquals() {
+  static void givenNullArgumentMatchers_hasBeenLastCalledWithParamsOfNull_callsAssertEquals() {
     // Arrange
     final MethodSpy spy = new MethodSpy('method');
     final FakeAsserter fakeAsserter = new FakeAsserter();
     final Assertions.MethodSpyAssertions sut = Assertions.assertThat(spy, fakeAsserter);
-    spy.call(null);
+    spy.call(new List<Object>());
 
     // Act
     try {
@@ -257,7 +257,7 @@ private class AssertionsTest {
     final MethodSpy spy = new MethodSpy('method');
     final FakeAsserter fakeAsserter = new FakeAsserter();
     final Assertions.MethodSpyAssertions sut = Assertions.assertThat(spy, fakeAsserter);
-    spy.call(null);
+    spy.call(new List<Object>());
 
     // Act & Assert
     sut.hasBeenCalledTimes(1);

--- a/force-app/classes/test/AssertionsTest.cls
+++ b/force-app/classes/test/AssertionsTest.cls
@@ -6,7 +6,7 @@
  */
 @IsTest
 private class AssertionsTest {
-  // As System.Assert* methods throws are not catchable
+  // As Assert.* methods throws are not catchable
   // Test are white box (implementation test instead of behavioural test)
   // We implemented a FakeAsserter class for the occasion
 
@@ -19,7 +19,7 @@ private class AssertionsTest {
     final Assertions.MethodSpyAssertions result = Assertions.assertThat(spy);
 
     // Assert
-    System.assertNotEquals(null, result);
+    Assert.isNotNull(result);
   }
 
   @isTest
@@ -33,8 +33,8 @@ private class AssertionsTest {
     sut.hasNotBeenCalled();
 
     // Assert
-    System.assertEquals(1, fakeAsserter.callCount);
-    System.assertEquals(false, fakeAsserter.failed);
+    Assert.areEqual(1, fakeAsserter.callCount);
+    Assert.isFalse(fakeAsserter.failed);
   }
 
   @isTest
@@ -48,9 +48,9 @@ private class AssertionsTest {
     sut.hasBeenCalled();
 
     // Assert
-    System.assertEquals(1, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not called', fakeAsserter.errorMessage);
+    Assert.areEqual(1, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not called', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -64,9 +64,9 @@ private class AssertionsTest {
     sut.hasBeenCalledWith(Params.of(new Account()));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not called with [(Account:{})]', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not called with [(Account:{})]', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -80,9 +80,9 @@ private class AssertionsTest {
     sut.hasBeenCalledWith(Params.ofList(new List<Object>{ new Account(), new Opportunity() }));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not called with [(Account:{}, Opportunity:{})]', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not called with [(Account:{}, Opportunity:{})]', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -96,9 +96,9 @@ private class AssertionsTest {
     sut.hasBeenCalledWith(Params.of(new Account(), Matcher.equals('test')));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not called with [(Account:{}, test)]', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not called with [(Account:{}, test)]', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -112,9 +112,9 @@ private class AssertionsTest {
     sut.hasBeenCalledWith(Params.empty());
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not called with [()]', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not called with [()]', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -130,8 +130,8 @@ private class AssertionsTest {
     sut.hasBeenCalledWith(Params.of(Matcher.equals('param')));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(false, fakeAsserter.failed);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isFalse(fakeAsserter.failed);
   }
 
   @isTest
@@ -145,9 +145,9 @@ private class AssertionsTest {
     // Act
     sut.hasBeenCalledWith(Params.of((Object) null));
 
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not called with [(null)]\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not called with [(null)]\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -161,9 +161,9 @@ private class AssertionsTest {
     sut.hasBeenLastCalledWith(Params.of((Object) null));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not last called with [(null)]', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not last called with [(null)]', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -177,9 +177,9 @@ private class AssertionsTest {
     sut.hasBeenLastCalledWith(Params.of(new Account()));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not last called with [(Account:{})]', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not last called with [(Account:{})]', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -193,9 +193,9 @@ private class AssertionsTest {
     sut.hasBeenLastCalledWith(Params.of(new Account(), Matcher.equals('test')));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not last called with [(Account:{}, test)]', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not last called with [(Account:{}, test)]', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -209,9 +209,9 @@ private class AssertionsTest {
     sut.hasBeenLastCalledWith(Params.of((Object) null));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not last called with [(null)]', fakeAsserter.errorMessage);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not last called with [(null)]', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -227,8 +227,8 @@ private class AssertionsTest {
     sut.hasBeenLastCalledWith(Params.of(Matcher.equals('param')));
 
     // Assert
-    System.assertEquals(2, fakeAsserter.callCount);
-    System.assertEquals(false, fakeAsserter.failed);
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isFalse(fakeAsserter.failed);
   }
 
   @isTest
@@ -240,15 +240,11 @@ private class AssertionsTest {
     spy.call(new List<Object>());
 
     // Act
-    try {
-      sut.hasBeenLastCalledWith(Params.of((Object) null));
+    sut.hasBeenLastCalledWith(Params.of((Object) null));
 
-      // Assert
-      System.assert(false); // Should not reach this point
-    } catch (Exception ex) {
-      System.assertEquals(false, fakeAsserter.failed);
-      System.assert(ex instanceof NullPointerException);
-    }
+    Assert.areEqual(2, fakeAsserter.callCount);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not last called with [(null)]\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -261,15 +257,15 @@ private class AssertionsTest {
 
     // Act & Assert
     sut.hasBeenCalledTimes(1);
-    System.assertEquals(false, fakeAsserter.failed);
+    Assert.isFalse(fakeAsserter.failed);
 
     sut.hasBeenCalledTimes(0);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not called 0 times\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not called 0 times\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
 
     sut.hasBeenCalledTimes(2);
-    System.assertEquals(true, fakeAsserter.failed);
-    System.assertEquals('Method method was not called 2 times\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
+    Assert.isTrue(fakeAsserter.failed);
+    Assert.areEqual('Method method was not called 2 times\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -282,7 +278,7 @@ private class AssertionsTest {
     sut.isFalse(false, new FakeErrorMessage('it works too'));
 
     // Assert
-    System.assert(true, 'This assertions should be reached');
+    Assert.isTrue(true, 'This assertions should be reached');
   }
 
   class FakeErrorMessage implements Assertions.ErrorMessage {

--- a/force-app/classes/test/MatcherTest.cls
+++ b/force-app/classes/test/MatcherTest.cls
@@ -3,7 +3,7 @@ public class MatcherTest {
   @isTest
   static void givenAnyMatcher_matchesAnyKindOfArgument() {
     // Arrange
-    ArgumentMatcher sut = Matcher.any();
+    final Matcher.ArgumentMatcher sut = Matcher.any();
 
     // Act & Assert
     System.assert(sut.matches(null));
@@ -27,7 +27,7 @@ public class MatcherTest {
   @isTest
   static void givenEqualsMatcher_matchesPrimitive() {
     // Arrange
-    ArgumentMatcher sut = Matcher.equals(10);
+    final Matcher.ArgumentMatcher sut = Matcher.equals(10);
 
     // Act & Assert
     System.assert(sut.matches(10));
@@ -52,7 +52,7 @@ public class MatcherTest {
   @isTest
   static void givenEqualsMatcher_matchesSObject() {
     // Arrange
-    ArgumentMatcher sut = Matcher.equals(new Account(Name = 'test'));
+    final Matcher.ArgumentMatcher sut = Matcher.equals(new Account(Name = 'test'));
 
     // Act & Assert
     System.assert(sut.matches(new Account(Name = 'test')));
@@ -77,7 +77,7 @@ public class MatcherTest {
   @isTest
   static void givenEqualsMatcher_matchesCustomType() {
     // Arrange
-    ArgumentMatcher sut = Matcher.equals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
+    final Matcher.ArgumentMatcher sut = Matcher.equals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
 
     // Act & Assert
     System.assert(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
@@ -103,7 +103,7 @@ public class MatcherTest {
   @isTest
   static void givenEqualsMatcher_matchesCollection() {
     // Arrange
-    ArgumentMatcher sut = Matcher.equals(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' });
+    final Matcher.ArgumentMatcher sut = Matcher.equals(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' });
 
     // Act & Assert
     System.assert(sut.matches(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' }));
@@ -129,7 +129,7 @@ public class MatcherTest {
   @isTest
   static void givenTypeMatcher_matchesPrimitive() {
     // Arrange
-    ArgumentMatcher sut = Matcher.ofType('Integer');
+    final Matcher.ArgumentMatcher sut = Matcher.ofType('Integer');
 
     // Act & Assert
     System.assert(sut.matches(10));
@@ -153,7 +153,7 @@ public class MatcherTest {
   @isTest
   static void givenTypeMatcher_matchesSObject() {
     // Arrange
-    ArgumentMatcher sut = Matcher.ofType(Account.getSObjectType());
+    final Matcher.ArgumentMatcher sut = Matcher.ofType(Account.getSObjectType());
 
     // Act & Assert
     System.assert(sut.matches(new Account()));
@@ -178,7 +178,7 @@ public class MatcherTest {
   @isTest
   static void givenTypeMatcher_matchesCustomType() {
     // Arrange
-    ArgumentMatcher sut = Matcher.ofType(CustomType.class);
+    final Matcher.ArgumentMatcher sut = Matcher.ofType(CustomType.class);
 
     // Act & Assert
     System.assert(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
@@ -203,7 +203,7 @@ public class MatcherTest {
   @isTest
   static void givenTypeMatcher_matchesDeriveType() {
     // Arrange
-    ArgumentMatcher sut = Matcher.ofType(ArgumentMatcher.class);
+    final Matcher.ArgumentMatcher sut = Matcher.ofType(Matcher.ArgumentMatcher.class);
 
     // Act & Assert
     System.assert(sut.matches(new ArgumentMatcherStub()));
@@ -228,7 +228,7 @@ public class MatcherTest {
   @isTest
   static void givenTypeMatcher_matchesCollection() {
     // Arrange
-    ArgumentMatcher sut = Matcher.ofType('List');
+    final Matcher.ArgumentMatcher sut = Matcher.ofType('List');
 
     // Act & Assert
     System.assert(sut.matches(new List<Object>{ 10, 'String', new Account() }));
@@ -252,7 +252,7 @@ public class MatcherTest {
   @isTest
   static void givenJSONMatcher_matchesPrimitive() {
     // Arrange
-    ArgumentMatcher sut = Matcher.jsonEquals(10);
+    final Matcher.ArgumentMatcher sut = Matcher.jsonEquals(10);
 
     // Act & Assert
     System.assert(sut.matches(10));
@@ -276,7 +276,7 @@ public class MatcherTest {
   @isTest
   static void givenJSONMatcher_matchesSObject() {
     // Arrange
-    ArgumentMatcher sut = Matcher.jsonEquals(new Account(Name = 'test'));
+    final Matcher.ArgumentMatcher sut = Matcher.jsonEquals(new Account(Name = 'test'));
 
     // Act & Assert
     System.assert(sut.matches(new Account(Name = 'test')));
@@ -300,7 +300,7 @@ public class MatcherTest {
   @isTest
   static void givenJSONMatcher_matchesCustomType() {
     // Arrange
-    ArgumentMatcher sut = Matcher.jsonEquals(new CustomType('test', 10, new Account(Name = 'test')));
+    final Matcher.ArgumentMatcher sut = Matcher.jsonEquals(new CustomType('test', 10, new Account(Name = 'test')));
 
     // Act & Assert
     System.assert(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
@@ -325,7 +325,7 @@ public class MatcherTest {
   @isTest
   static void givenJSONMatcher_matchesCollection() {
     // Arrange
-    ArgumentMatcher sut = Matcher.jsonEquals(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' });
+    final Matcher.ArgumentMatcher sut = Matcher.jsonEquals(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' });
 
     // Act & Assert
     System.assert(sut.matches(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' }));
@@ -382,7 +382,7 @@ public class MatcherTest {
     }
   }
 
-  public class ArgumentMatcherStub implements ArgumentMatcher {
+  public class ArgumentMatcherStub implements Matcher.ArgumentMatcher {
     public Boolean matches(final Object callArgument) {
       return true;
     }

--- a/force-app/classes/test/MatcherTest.cls
+++ b/force-app/classes/test/MatcherTest.cls
@@ -6,22 +6,22 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.any();
 
     // Act & Assert
-    System.assert(sut.matches(null));
-    System.assert(sut.matches(Date.today()));
-    System.assert(sut.matches(DateTime.now()));
-    System.assert(sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(sut.matches(Blob.valueOf('test')));
-    System.assert(sut.matches(false));
-    System.assert(sut.matches(true));
-    System.assert(sut.matches(new Account(Name = 'test')));
-    System.assert(sut.matches(10));
-    System.assert(sut.matches(10.2));
-    System.assert(sut.matches('test'));
-    System.assert(sut.matches('001000000000011AAA'));
-    System.assert(sut.matches(new List<Object>()));
-    System.assert(sut.matches(new Set<Object>()));
-    System.assert(sut.matches(new Map<Id, Object>()));
-    System.assert(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isTrue(sut.matches(null));
+    Assert.isTrue(sut.matches(Date.today()));
+    Assert.isTrue(sut.matches(DateTime.now()));
+    Assert.isTrue(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isTrue(sut.matches(Blob.valueOf('test')));
+    Assert.isTrue(sut.matches(false));
+    Assert.isTrue(sut.matches(true));
+    Assert.isTrue(sut.matches(new Account(Name = 'test')));
+    Assert.isTrue(sut.matches(10));
+    Assert.isTrue(sut.matches(10.2));
+    Assert.isTrue(sut.matches('test'));
+    Assert.isTrue(sut.matches('001000000000011AAA'));
+    Assert.isTrue(sut.matches(new List<Object>()));
+    Assert.isTrue(sut.matches(new Set<Object>()));
+    Assert.isTrue(sut.matches(new Map<Id, Object>()));
+    Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
@@ -30,23 +30,23 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.equals(10);
 
     // Act & Assert
-    System.assert(sut.matches(10));
+    Assert.isTrue(sut.matches(10));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
-    System.assert(!sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
@@ -55,23 +55,23 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.equals(new Account(Name = 'test'));
 
     // Act & Assert
-    System.assert(sut.matches(new Account(Name = 'test')));
+    Assert.isTrue(sut.matches(new Account(Name = 'test')));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
-    System.assert(!sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
@@ -80,24 +80,24 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.equals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
 
     // Act & Assert
-    System.assert(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
+    Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
-    System.assert(!sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
@@ -106,24 +106,24 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.equals(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' });
 
     // Act & Assert
-    System.assert(sut.matches(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' }));
+    Assert.isTrue(sut.matches(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' }));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
-    System.assert(!sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
@@ -132,22 +132,22 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.ofType('Integer');
 
     // Act & Assert
-    System.assert(sut.matches(10));
+    Assert.isTrue(sut.matches(10));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
   }
 
   @isTest
@@ -156,23 +156,23 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.ofType(Account.getSObjectType());
 
     // Act & Assert
-    System.assert(sut.matches(new Account()));
+    Assert.isTrue(sut.matches(new Account()));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
-    System.assert(!sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
@@ -181,23 +181,23 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.ofType(CustomType.class);
 
     // Act & Assert
-    System.assert(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
   }
 
   @isTest
@@ -206,23 +206,23 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.ofType(Matcher.ArgumentMatcher.class);
 
     // Act & Assert
-    System.assert(sut.matches(new ArgumentMatcherStub()));
+    Assert.isTrue(sut.matches(new ArgumentMatcherStub()));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
   }
 
   @isTest
@@ -231,22 +231,22 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.ofType('List');
 
     // Act & Assert
-    System.assert(sut.matches(new List<Object>{ 10, 'String', new Account() }));
+    Assert.isTrue(sut.matches(new List<Object>{ 10, 'String', new Account() }));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
   }
 
   @isTest
@@ -255,22 +255,22 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.jsonEquals(10);
 
     // Act & Assert
-    System.assert(sut.matches(10));
+    Assert.isTrue(sut.matches(10));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
   }
 
   @isTest
@@ -279,22 +279,22 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.jsonEquals(new Account(Name = 'test'));
 
     // Act & Assert
-    System.assert(sut.matches(new Account(Name = 'test')));
+    Assert.isTrue(sut.matches(new Account(Name = 'test')));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
   }
 
   @isTest
@@ -303,23 +303,23 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.jsonEquals(new CustomType('test', 10, new Account(Name = 'test')));
 
     // Act & Assert
-    System.assert(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
   }
 
   @isTest
@@ -328,23 +328,23 @@ public class MatcherTest {
     final Matcher.ArgumentMatcher sut = Matcher.jsonEquals(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' });
 
     // Act & Assert
-    System.assert(sut.matches(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' }));
+    Assert.isTrue(sut.matches(new Map<String, Object>{ 'A' => new Account(), 'B' => 'test' }));
 
-    System.assert(!sut.matches(null));
-    System.assert(!sut.matches(Date.today()));
-    System.assert(!sut.matches(DateTime.now()));
-    System.assert(!sut.matches(Time.newInstance(12, 12, 12, 12)));
-    System.assert(!sut.matches(Blob.valueOf('test')));
-    System.assert(!sut.matches(false));
-    System.assert(!sut.matches(true));
-    System.assert(!sut.matches(10));
-    System.assert(!sut.matches(10.2));
-    System.assert(!sut.matches('test'));
-    System.assert(!sut.matches('001000000000011AAA'));
-    System.assert(!sut.matches(new Account(Name = 'test')));
-    System.assert(!sut.matches(new List<Object>()));
-    System.assert(!sut.matches(new Set<Object>()));
-    System.assert(!sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
   }
 
   virtual class CustomType {

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -17,9 +17,9 @@ private class MethodSpyTest {
       sut.whenCalledWith(null);
 
       // Assert
-      System.assert(false, 'it should not reach this line');
+      Assert.fail('it should not reach this line');
     } catch (Exception ex) {
-      System.assert(ex instanceof Matcher.MatcherException);
+      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
     }
   }
 
@@ -33,9 +33,9 @@ private class MethodSpyTest {
       sut.hasBeenCalledWith(null);
 
       // Assert
-      System.assert(false, 'it should not reach this line');
+      Assert.fail('it should not reach this line');
     } catch (Exception ex) {
-      System.assert(ex instanceof Matcher.MatcherException);
+      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
     }
   }
 
@@ -50,9 +50,9 @@ private class MethodSpyTest {
       sut.hasBeenCalledWith(null);
 
       // Assert
-      System.assert(false, 'it should not reach this line');
+      Assert.fail('it should not reach this line');
     } catch (Exception ex) {
-      System.assert(ex instanceof Matcher.MatcherException);
+      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
     }
   }
 
@@ -66,9 +66,9 @@ private class MethodSpyTest {
       sut.hasBeenLastCalledWith(null);
 
       // Assert
-      System.assert(false, 'it should not reach this line');
+      Assert.fail('it should not reach this line');
     } catch (Exception ex) {
-      System.assert(ex instanceof Matcher.MatcherException);
+      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
     }
   }
 
@@ -83,9 +83,9 @@ private class MethodSpyTest {
       sut.hasBeenLastCalledWith(null);
 
       // Assert
-      System.assert(false, 'it should not reach this line');
+      Assert.fail('it should not reach this line');
     } catch (Exception ex) {
-      System.assert(ex instanceof Matcher.MatcherException);
+      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
     }
   }
 
@@ -99,9 +99,9 @@ private class MethodSpyTest {
     final Object result = sut.call(new List<Object>());
 
     // Assert
-    System.assertEquals('test', result);
-    System.assertEquals(true, sut.hasBeenCalledWith(Params.empty()));
-    System.assertEquals(true, sut.hasBeenLastCalledWith(Params.empty()));
+    Assert.areEqual('test', result);
+    Assert.areEqual(true, sut.hasBeenCalledWith(Params.empty()));
+    Assert.areEqual(true, sut.hasBeenLastCalledWith(Params.empty()));
   }
 
   @IsTest
@@ -115,10 +115,10 @@ private class MethodSpyTest {
 
     // Assert
     final Params expectedArgs = Params.of('param', new Account(Name = 'Test'), Matcher.any());
-    System.assertEquals('Expected Result', result);
-    System.assertEquals(true, sut.hasBeenCalledWith(expectedArgs));
-    System.assertEquals(false, sut.hasBeenLastCalledWith(Params.empty()));
-    System.assertEquals(true, sut.hasBeenLastCalledWith(expectedArgs));
+    Assert.areEqual('Expected Result', result);
+    Assert.areEqual(true, sut.hasBeenCalledWith(expectedArgs));
+    Assert.areEqual(false, sut.hasBeenLastCalledWith(Params.empty()));
+    Assert.areEqual(true, sut.hasBeenLastCalledWith(expectedArgs));
   }
 
   @IsTest
@@ -132,10 +132,10 @@ private class MethodSpyTest {
       final Object result = sut.call(new List<Object>{ 'param' });
 
       // Assert
-      System.assert(false, 'we shoud not reach this line');
+      Assert.fail('it shoud not reach this line');
     } catch (IllegalArgumentException iaex) {
       final Params expectedArgs = Params.of('param', new Account(Name = 'Test'), Matcher.any());
-      System.assertEquals(false, sut.hasBeenCalledWith(expectedArgs));
+      Assert.areEqual(false, sut.hasBeenCalledWith(expectedArgs));
     }
   }
 
@@ -150,10 +150,10 @@ private class MethodSpyTest {
       final Object result = sut.call(new List<Object>{ new Opportunity() });
 
       // Assert
-      System.assert(false, 'we shoud not reach this line');
+      Assert.fail('it shoud not reach this line');
     } catch (IllegalArgumentException iaex) {
       Params expectedArgs = Params.of('param', new Account(Name = 'Test'));
-      System.assertEquals(false, sut.hasBeenCalledWith(expectedArgs));
+      Assert.areEqual(false, sut.hasBeenCalledWith(expectedArgs));
     }
   }
 
@@ -169,10 +169,10 @@ private class MethodSpyTest {
 
     // Assert
     final Params expectedArgs = Params.of(Matcher.jsonEquals(new List<String>{ 'test' }), Matcher.ofType(Account.getSObjectType()), Matcher.any());
-    System.assertEquals('Expected Result', result);
-    System.assertEquals(true, sut.hasBeenCalledWith(expectedArgs));
-    System.assertEquals(false, sut.hasBeenLastCalledWith(Params.empty()));
-    System.assertEquals(true, sut.hasBeenLastCalledWith(expectedArgs));
+    Assert.areEqual('Expected Result', result);
+    Assert.areEqual(true, sut.hasBeenCalledWith(expectedArgs));
+    Assert.areEqual(false, sut.hasBeenLastCalledWith(Params.empty()));
+    Assert.areEqual(true, sut.hasBeenLastCalledWith(expectedArgs));
   }
 
   @IsTest
@@ -184,9 +184,9 @@ private class MethodSpyTest {
 
     // Act && Assert
     final Object firstCallResult = sut.call(new List<Object>{ new Account() });
-    System.assertEquals('Account result', firstCallResult);
+    Assert.areEqual('Account result', firstCallResult);
     final Object secondCallResult = sut.call(new List<Object>{ new Opportunity() });
-    System.assertEquals('Opportunity result', secondCallResult);
+    Assert.areEqual('Opportunity result', secondCallResult);
   }
 
   static void givenSpy_whenCalledWithDifferentArgumentType_itCallsTheSameSpy() {
@@ -196,9 +196,9 @@ private class MethodSpyTest {
 
     // Act && Assert
     final Object result = sut.call(new List<Object>{ new Account() });
-    System.assertEquals('String result', result);
+    Assert.areEqual('String result', result);
     result = sut.call(new List<Object>{ new Opportunity() });
-    System.assertEquals('String result', result);
+    Assert.areEqual('String result', result);
   }
 
   @IsTest
@@ -211,7 +211,7 @@ private class MethodSpyTest {
     final Object result = sut.call(new List<Object>{});
 
     // Assert
-    System.assertEquals('String result', result);
+    Assert.areEqual('String result', result);
   }
 
   @IsTest
@@ -226,7 +226,7 @@ private class MethodSpyTest {
     final Object result = sut.call(new List<Object>{});
 
     // Assert
-    System.assertEquals('Last Configuration', result);
+    Assert.areEqual('Last Configuration', result);
   }
 
   @IsTest
@@ -238,10 +238,10 @@ private class MethodSpyTest {
     try {
       // Act
       sut.call(new List<Object>{});
-      System.assert(false, 'test should have throw an exception');
+      Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       // Assert
-      System.assertEquals('test exception', e.getMessage());
+      Assert.areEqual('test exception', e.getMessage());
     }
   }
 
@@ -259,10 +259,10 @@ private class MethodSpyTest {
     try {
       // Act
       sut.call(new List<Object>{});
-      System.assert(false, 'test should have throw an exception');
+      Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       // Assert
-      System.assertEquals(exception3.getMessage(), e.getMessage());
+      Assert.areEqual(exception3.getMessage(), e.getMessage());
     }
   }
 
@@ -275,10 +275,10 @@ private class MethodSpyTest {
     try {
       // Act
       sut.call(new List<Object>{ 'Expected Param' });
-      System.assert(false, 'test should have throw an exception');
+      Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       // Assert
-      System.assertEquals('test exception', e.getMessage());
+      Assert.areEqual('test exception', e.getMessage());
     }
   }
 
@@ -292,7 +292,7 @@ private class MethodSpyTest {
     final Object result = sut.call(new List<Object>{ 'Expected Param' });
 
     // Assert
-    System.assertEquals('Expected Result', result);
+    Assert.areEqual('Expected Result', result);
   }
 
   @IsTest
@@ -307,8 +307,8 @@ private class MethodSpyTest {
     final Object result2 = sut.call(new List<Object>{ 'Expected Param 2' });
 
     // Assert
-    System.assertEquals('Expected Result 1', result1);
-    System.assertEquals('Expected Result 2', result2);
+    Assert.areEqual('Expected Result 1', result1);
+    Assert.areEqual('Expected Result 2', result2);
   }
 
   @IsTest
@@ -321,7 +321,7 @@ private class MethodSpyTest {
     final Object result = sut.call(new List<Object>{ 'Expected First Param', true });
 
     // Assert
-    System.assertEquals('Expected Result', result);
+    Assert.areEqual('Expected Result', result);
   }
 
   @IsTest
@@ -334,7 +334,7 @@ private class MethodSpyTest {
     final Object result = sut.call(new List<Object>{ new Account(), true });
 
     // Assert
-    System.assertEquals('Expected Result', result);
+    Assert.areEqual('Expected Result', result);
   }
 
   @IsTest
@@ -347,9 +347,9 @@ private class MethodSpyTest {
     try {
       final Object result = sut.call(new List<Object>{ new Opportunity(), true });
       // Assert
-      System.assert(false, 'test should have throw an exception');
+      Assert.fail('it shoud not reach this line');
     } catch (Exception ex) {
-      System.assert(ex instanceof IllegalArgumentException, 'Exception should be IllegalArgumentException');
+      Assert.isInstanceOfType(ex, IllegalArgumentException.class, 'Exception should be IllegalArgumentException');
     }
   }
 
@@ -365,8 +365,8 @@ private class MethodSpyTest {
     final Object result2 = sut.call(new List<Object>{ 'Expected First Param 2', false });
 
     // Assert
-    System.assertEquals('Expected Result 1', result1);
-    System.assertEquals('Expected Result 2', result2);
+    Assert.areEqual('Expected Result 1', result1);
+    Assert.areEqual('Expected Result 2', result2);
   }
 
   @IsTest
@@ -378,7 +378,7 @@ private class MethodSpyTest {
     final object actual = sut.call(new List<Object>{});
 
     // Assert
-    System.assertEquals(null, actual);
+    Assert.areEqual(null, actual);
   }
 
   @IsTest
@@ -389,10 +389,10 @@ private class MethodSpyTest {
     try {
       // Act
       sut.call(new List<Object>{ 'Another Param', false });
-      System.assert(false, 'test should have throw an exception');
+      Assert.fail('it shoud not reach this line');
     } catch (IllegalArgumentException e) {
       // Assert
-      System.assertEquals('methodName: No stub value found for a call with params (Another Param, false)', e.getMessage());
+      Assert.areEqual('methodName: No stub value found for a call with params (Another Param, false)', e.getMessage());
     }
   }
 
@@ -408,8 +408,8 @@ private class MethodSpyTest {
     final Object result2 = sut.call(new List<Object>{ 'Another Param', false });
 
     // Assert
-    System.assertEquals('Expected Result', result1);
-    System.assertEquals('Default Result', result2);
+    Assert.areEqual('Expected Result', result1);
+    Assert.areEqual('Default Result', result2);
   }
 
   @IsTest
@@ -424,8 +424,8 @@ private class MethodSpyTest {
     final Object result2 = sut.call(new List<Object>{ 'Another Param', false });
 
     // Assert
-    System.assertEquals('Expected Result', result1);
-    System.assertEquals('Default Result', result2);
+    Assert.areEqual('Expected Result', result1);
+    Assert.areEqual('Default Result', result2);
   }
 
   @IsTest
@@ -438,7 +438,7 @@ private class MethodSpyTest {
     final Boolean hasBeenCalled = sut.hasBeenCalled();
 
     // Assert
-    System.assert(!hasBeenCalled);
+    Assert.isFalse(hasBeenCalled);
   }
 
   @IsTest
@@ -452,7 +452,7 @@ private class MethodSpyTest {
     final Boolean hasBeenCalled = sut.hasBeenCalled();
 
     // Assert
-    System.assert(hasBeenCalled);
+    Assert.isTrue(hasBeenCalled);
   }
 
   @IsTest
@@ -462,10 +462,10 @@ private class MethodSpyTest {
     sut.returns('any result');
 
     // Act && Assert
-    System.assert(!sut.hasBeenCalledTimes(-1));
-    System.assert(sut.hasBeenCalledTimes(0));
-    System.assert(!sut.hasBeenCalledTimes(1));
-    System.assert(!sut.hasBeenCalledTimes(5));
+    Assert.isFalse(sut.hasBeenCalledTimes(-1));
+    Assert.isTrue(sut.hasBeenCalledTimes(0));
+    Assert.isFalse(sut.hasBeenCalledTimes(1));
+    Assert.isFalse(sut.hasBeenCalledTimes(5));
   }
 
   @IsTest
@@ -476,10 +476,10 @@ private class MethodSpyTest {
     sut.call(new List<Object>{});
 
     // Act && Assert
-    System.assert(!sut.hasBeenCalledTimes(-1));
-    System.assert(!sut.hasBeenCalledTimes(0));
-    System.assert(sut.hasBeenCalledTimes(1));
-    System.assert(!sut.hasBeenCalledTimes(5));
+    Assert.isFalse(sut.hasBeenCalledTimes(-1));
+    Assert.isFalse(sut.hasBeenCalledTimes(0));
+    Assert.isTrue(sut.hasBeenCalledTimes(1));
+    Assert.isFalse(sut.hasBeenCalledTimes(5));
   }
 
   @IsTest
@@ -494,11 +494,11 @@ private class MethodSpyTest {
     sut.call(new List<Object>{});
 
     // Act && Assert
-    System.assert(!sut.hasBeenCalledTimes(-1));
-    System.assert(!sut.hasBeenCalledTimes(0));
-    System.assert(!sut.hasBeenCalledTimes(1));
-    System.assert(sut.hasBeenCalledTimes(5));
-    System.assert(!sut.hasBeenCalledTimes(6));
+    Assert.isFalse(sut.hasBeenCalledTimes(-1));
+    Assert.isFalse(sut.hasBeenCalledTimes(0));
+    Assert.isFalse(sut.hasBeenCalledTimes(1));
+    Assert.isTrue(sut.hasBeenCalledTimes(5));
+    Assert.isFalse(sut.hasBeenCalledTimes(6));
   }
 
   @IsTest
@@ -511,8 +511,8 @@ private class MethodSpyTest {
     sut.call(last);
 
     // Act && Assert
-    System.assert(!sut.hasBeenLastCalledWith(Params.of(new Opportunity())));
-    System.assert(sut.hasBeenLastCalledWith(Params.of(new Account())));
+    Assert.isFalse(sut.hasBeenLastCalledWith(Params.of(new Opportunity())));
+    Assert.isTrue(sut.hasBeenLastCalledWith(Params.of(new Account())));
   }
 
   @IsTest
@@ -522,9 +522,9 @@ private class MethodSpyTest {
     final MethodSpy sut = new MethodSpy('methodName');
 
     // Act & Assert
-    System.assert(!sut.hasBeenLastCalledWith(Params.empty()));
+    Assert.isFalse(sut.hasBeenLastCalledWith(Params.empty()));
     sut.call(param);
-    System.assert(sut.hasBeenLastCalledWith(Params.empty()));
+    Assert.isTrue(sut.hasBeenLastCalledWith(Params.empty()));
   }
 
   @IsTest
@@ -534,9 +534,9 @@ private class MethodSpyTest {
     final MethodSpy sut = new MethodSpy('methodName');
 
     // Act & Assert
-    System.assert(!sut.hasBeenLastCalledWith(Params.of(Matcher.any())));
+    Assert.isFalse(sut.hasBeenLastCalledWith(Params.of(Matcher.any())));
     sut.call(new List<Object>{ param });
-    System.assert(sut.hasBeenLastCalledWith(Params.of(Matcher.any())));
+    Assert.isTrue(sut.hasBeenLastCalledWith(Params.of(Matcher.any())));
   }
 
   @IsTest
@@ -550,9 +550,9 @@ private class MethodSpyTest {
 
     // Act && Assert
 
-    System.assert(sut.hasBeenCalledWith(Params.of(new Opportunity())));
-    System.assert(sut.hasBeenCalledWith(Params.of(new Account())));
-    System.assert(!sut.hasBeenCalledWith(Params.of(new Case())));
+    Assert.isTrue(sut.hasBeenCalledWith(Params.of(new Opportunity())));
+    Assert.isTrue(sut.hasBeenCalledWith(Params.of(new Account())));
+    Assert.isFalse(sut.hasBeenCalledWith(Params.of(new Case())));
   }
 
   @IsTest
@@ -562,9 +562,9 @@ private class MethodSpyTest {
     final MethodSpy sut = new MethodSpy('methodName');
 
     // Act & Assert
-    System.assert(!sut.hasBeenCalledWith(Params.empty()));
+    Assert.isFalse(sut.hasBeenCalledWith(Params.empty()));
     sut.call(param);
-    System.assert(sut.hasBeenCalledWith(Params.empty()));
+    Assert.isTrue(sut.hasBeenCalledWith(Params.empty()));
   }
 
   @IsTest
@@ -574,9 +574,9 @@ private class MethodSpyTest {
     final MethodSpy sut = new MethodSpy('methodName');
 
     // Act & Assert
-    System.assert(!sut.hasBeenCalledWith(Params.of(Matcher.any())));
+    Assert.isFalse(sut.hasBeenCalledWith(Params.of(Matcher.any())));
     sut.call(new List<Object>{ param });
-    System.assert(sut.hasBeenCalledWith(Params.of(Matcher.any())));
+    Assert.isTrue(sut.hasBeenCalledWith(Params.of(Matcher.any())));
   }
 
   @IsTest
@@ -586,9 +586,9 @@ private class MethodSpyTest {
     final MethodSpy sut = new MethodSpy('methodName');
 
     // Act & Assert
-    System.assert(!sut.hasBeenCalledWith(Params.of(Matcher.jsonEquals(param))));
+    Assert.isFalse(sut.hasBeenCalledWith(Params.of(Matcher.jsonEquals(param))));
     sut.call(new List<Object>{ param });
-    System.assert(sut.hasBeenCalledWith(Params.of(Matcher.jsonEquals(param))));
+    Assert.isTrue(sut.hasBeenCalledWith(Params.of(Matcher.jsonEquals(param))));
   }
 
   @IsTest
@@ -603,7 +603,7 @@ private class MethodSpyTest {
 
     // Assert
     final Object expected = new Account();
-    System.assertEquals(expected, actual, 'custom apex identical list should match');
+    Assert.areEqual(expected, actual, 'custom apex identical list should match');
   }
 
   @IsTest
@@ -618,9 +618,9 @@ private class MethodSpyTest {
       final Object actual = sut.call(new List<Object>{ new Account() });
 
       // Assert
-      System.assert(false); // Should not reach this point
+      Assert.fail('it should not reach this line');
     } catch (IllegalArgumentException ex) {
-      System.assertNotEquals(null, ex, 'exception should be thrown');
+      Assert.isNotNull(ex, 'exception should be thrown');
     }
   }
 
@@ -636,7 +636,7 @@ private class MethodSpyTest {
 
     // Assert
     final Object expected = new Account();
-    System.assertEquals(expected, actual, 'custom apex with equals identical list should match');
+    Assert.areEqual(expected, actual, 'custom apex with equals identical list should match');
   }
 
   @IsTest
@@ -651,7 +651,7 @@ private class MethodSpyTest {
 
     // Assert
     final Object expected = new Account();
-    System.assertEquals(expected, actual, 'Not serializable custom apex identical list should match');
+    Assert.areEqual(expected, actual, 'Not serializable custom apex identical list should match');
   }
 
   @IsTest
@@ -664,15 +664,15 @@ private class MethodSpyTest {
 
     // Act & Assert
     final Object result1 = sut.call(new List<Object>{ 1 });
-    System.assertEquals('result 1', result1);
+    Assert.areEqual('result 1', result1);
 
     // Act & Assert
     final Object result2 = sut.call(new List<Object>{ 2 });
-    System.assertEquals('result 2', result2);
+    Assert.areEqual('result 2', result2);
 
     // Act & Assert
     final Object resultDefault = sut.call(new List<Object>{ 3 });
-    System.assertEquals('result default', resultDefault);
+    Assert.areEqual('result default', resultDefault);
   }
 
   @IsTest
@@ -685,9 +685,9 @@ private class MethodSpyTest {
     // Act & Assert
     try {
       sut.call(new List<Object>{ 1 });
-      System.assert(false, 'test should have throw an exception');
+      Assert.fail('it should not reach this line');
     } catch (Exception e) {
-      System.assertEquals('test exception', e.getMessage());
+      Assert.areEqual('test exception', e.getMessage());
     }
   }
 
@@ -702,7 +702,7 @@ private class MethodSpyTest {
     final Object result = sut.call(new List<Object>{ 1 });
 
     // Assert
-    System.assertEquals('result', result);
+    Assert.areEqual('result', result);
   }
 
   @IsTest
@@ -715,15 +715,15 @@ private class MethodSpyTest {
 
     // Act & Assert
     final Object result1 = sut.call(new List<Object>{ 1 });
-    System.assertEquals('result 1', result1);
+    Assert.areEqual('result 1', result1);
 
     // Act & Assert
     final Object result2 = sut.call(new List<Object>{ 2 });
-    System.assertEquals('result 2', result2);
+    Assert.areEqual('result 2', result2);
 
     // Act & Assert
     final Object resultDefault = sut.call(new List<Object>{ 3 });
-    System.assertEquals('result default', resultDefault);
+    Assert.areEqual('result default', resultDefault);
   }
 
   @IsTest
@@ -736,18 +736,18 @@ private class MethodSpyTest {
 
     // Act & Assert
     final Object result1 = sut.call(new List<Object>{ 1 });
-    System.assertEquals('result 1', result1);
+    Assert.areEqual('result 1', result1);
 
     // Act & Assert
     final Object result2 = sut.call(new List<Object>{ 2 });
-    System.assertEquals('result 2', result2);
+    Assert.areEqual('result 2', result2);
 
     // Act & Assert
     try {
       sut.call(new List<Object>{ 3 });
-      System.assert(false, 'test should have throw an exception');
+      Assert.fail('it should not reach this line');
     } catch (Exception e) {
-      System.assertEquals('test exception', e.getMessage());
+      Assert.areEqual('test exception', e.getMessage());
     }
   }
 
@@ -761,18 +761,18 @@ private class MethodSpyTest {
 
     // Act & Assert
     final Object result1 = sut.call(new List<Object>{ 1 });
-    System.assertEquals('result 1', result1);
+    Assert.areEqual('result 1', result1);
 
     // Act & Assert
     final Object result2 = sut.call(new List<Object>{ 2 });
-    System.assertEquals('result 2', result2);
+    Assert.areEqual('result 2', result2);
 
     // Act & Assert
     try {
       sut.call(new List<Object>{ 3 });
-      System.assert(false, 'test should have throw an exception');
+      Assert.fail('it should not reach this line');
     } catch (Exception e) {
-      System.assertEquals('test exception', e.getMessage());
+      Assert.areEqual('test exception', e.getMessage());
     }
   }
 

--- a/force-app/classes/test/MockTest.cls
+++ b/force-app/classes/test/MockTest.cls
@@ -20,7 +20,7 @@ private class MockTest {
     final String result = sut.dummyMethod();
 
     // Assert
-    System.assertEquals(expected, result);
+    Assert.areEqual(expected, result);
   }
 
   @IsTest
@@ -36,7 +36,7 @@ private class MockTest {
     final Object result = sut.dummyMethod();
 
     // Assert
-    System.assertEquals(null, result);
+    Assert.areEqual(null, result);
   }
 
   // Unit test
@@ -50,7 +50,7 @@ private class MockTest {
     final MethodSpy result = sut.spyOn(expected);
 
     // Assert
-    System.assertEquals(expected, result.methodName);
+    Assert.areEqual(expected, result.methodName);
   }
 
   @IsTest
@@ -64,7 +64,7 @@ private class MockTest {
     final MethodSpy result = sut.spyOn(methodName);
 
     // Assert
-    System.assertEquals(expected, result);
+    Assert.areEqual(expected, result);
   }
 
   @IsTest
@@ -77,7 +77,7 @@ private class MockTest {
     final MethodSpy result = sut.getSpy(methodName);
 
     // Assert
-    System.assertEquals(null, result);
+    Assert.areEqual(null, result);
   }
 
   @IsTest
@@ -91,7 +91,7 @@ private class MockTest {
     final MethodSpy result = sut.getSpy(methodName);
 
     // Assert
-    System.assertEquals(expected, result);
+    Assert.areEqual(expected, result);
   }
 
   @IsTest
@@ -103,7 +103,7 @@ private class MockTest {
     final Mock result = Mock.forType(param);
 
     // Assert
-    System.assertNotEquals(null, result);
+    Assert.areNotEqual(null, result);
   }
 
   @IsTest
@@ -115,9 +115,9 @@ private class MockTest {
     try {
       final Mock result = Mock.forType(param);
       // Assert
-      System.assert(false);
+      Assert.fail('it should not reach this line');
     } catch (Exception ex) {
-      System.assertNotEquals(null, ex);
+      Assert.areNotEqual(null, ex);
     }
   }
 }

--- a/force-app/classes/test/ParamsTest.cls
+++ b/force-app/classes/test/ParamsTest.cls
@@ -7,91 +7,89 @@
 @IsTest
 private class ParamsTest {
   @isTest
-  static void givenNothing_whenOfIsCalled_listOfArgsContains0Element() {
+  static void givenNothing_whenOfIsCalled_matchesEmptyList() {
     // Arrange
-    Params sut;
+    final Params sut = Params.empty();
 
     // Act
-    sut = Params.empty();
-    // TODO match stuff and assert the result
     final Boolean result = sut.matches(new List<Object>());
 
     // Assert
-    System.assertEquals(true, result);
+    Assert.isTrue(result);
   }
 
   @isTest
-  static void given1Object_whenOfIsCalled_listOfArgsContains1Element() {
+  static void given1Object_whenOfIsCalled_matchesTheElement() {
     // Arrange
-    Params sut;
+    final Params sut = Params.of('test');
 
     // Act
-    sut = Params.of('test');
+    final Boolean result = sut.matches(new List<Object>{ 'test' });
 
     // Assert
-    System.assertEquals(1, sut.listOfArgs.size());
-    assertListOfArgsElementsAreArgumentMatcher(sut);
+    Assert.isTrue(result);
   }
 
   @isTest
-  static void given2Objects_whenOfIsCalled_listOfArgsContains2Elements() {
+  static void given2Objects_whenOfIsCalled_matchesElementsInOrder() {
     // Arrange
-    Params sut;
+    final Params sut = Params.of('test', 10);
 
     // Act
-    sut = Params.of('test', 10);
+    final Boolean positive = sut.matches(new List<Object>{ 'test', 10 });
+    final Boolean negative = sut.matches(new List<Object>{ 10, 'test' });
 
     // Assert
-    System.assertEquals(2, sut.listOfArgs.size());
-    assertListOfArgsElementsAreArgumentMatcher(sut);
+    Assert.isTrue(positive);
+    Assert.isFalse(negative);
   }
 
   @isTest
-  static void given3Objects_whenOfIsCalled_listOfArgsContains3Elements() {
+  static void given3Objects_whenOfIsCalled_matchesElementsInOrder() {
     // Arrange
-    Params sut;
+    final Params sut = Params.of('test', 10, new Account());
 
     // Act
-    sut = Params.of('test', 10, new Account());
+    final Boolean positive = sut.matches(new List<Object>{ 'test', 10, new Account() });
+    final Boolean negative = sut.matches(new List<Object>{ 10, 'test', new Account() });
 
     // Assert
-    System.assertEquals(3, sut.listOfArgs.size());
-    assertListOfArgsElementsAreArgumentMatcher(sut);
+    Assert.isTrue(positive);
+    Assert.isFalse(negative);
   }
 
   @isTest
-  static void given4Objects_whenOfIsCalled_listOfArgsContains4Elements() {
+  static void given4Objects_whenOfIsCalled_matchesElementsInOrder() {
     // Arrange
-    Params sut;
+    final Params sut = Params.of('test', 10, new Account(), new List<Date>());
 
     // Act
-    sut = Params.of('test', 10, new Account(), new List<Date>());
+    final Boolean positive = sut.matches(new List<Object>{ 'test', 10, new Account(), new List<Date>() });
+    final Boolean negative = sut.matches(new List<Object>{ 10, 'test', new Account(), new List<Date>() });
 
     // Assert
-    System.assertEquals(4, sut.listOfArgs.size());
-    assertListOfArgsElementsAreArgumentMatcher(sut);
+    Assert.isTrue(positive);
+    Assert.isFalse(negative);
   }
 
   @isTest
-  static void given5Objects_whenOfIsCalled_listOfArgsContains5Elements() {
+  static void given5Objects_whenOfIsCalled_matchesElementsInOrder() {
     // Arrange
-    Params sut;
+    final Params sut = Params.of('test', 10, new Account(), new List<Date>(), new Map<Id, Set<String>>());
 
     // Act
-    sut = Params.of('test', 10, new Account(), new List<Date>(), new Map<Id, Set<String>>());
+    final Boolean positive = sut.matches(new List<Object>{ 'test', 10, new Account(), new List<Date>(), new Map<Id, Set<String>>() });
+    final Boolean negative = sut.matches(new List<Object>{ 10, 'test', new Account(), new List<Date>(), new Map<Id, Set<String>>() });
 
     // Assert
-    System.assertEquals(5, sut.listOfArgs.size());
-    assertListOfArgsElementsAreArgumentMatcher(sut);
+    Assert.isTrue(positive);
+    Assert.isFalse(negative);
   }
 
   @isTest
-  static void givenListOf10MixType_whenOfListIsCalledWithList_listOfArgsContains10Elements() {
+  static void givenListOf10MixType_whenOfListIsCalledWithList_matchesElementsInOrder() {
     // Arrange
-    Params sut;
-
-    // Act
-    sut = Params.ofList(
+    final Params sut = Params.ofList(
       new List<Object>{
         Matcher.equals('test'),
         Matcher.equals(10),
@@ -106,27 +104,41 @@ private class ParamsTest {
       }
     );
 
+    // Act
+    final Boolean positive = sut.matches(
+      new List<Object>{
+        'test',
+        10,
+        new Account(),
+        new List<Date>(),
+        new Map<Id, Set<String>>(),
+        new Set<Date>(),
+        new List<Account>(),
+        Blob.valueOf('test'),
+        'test',
+        new CustomType()
+      }
+    );
+    final Boolean negative = sut.matches(new List<Object>{ 10, 'test', new Account(), new List<Date>(), new Map<Id, Set<String>>() });
+
     // Assert
-    System.assertEquals(10, sut.listOfArgs.size());
-    assertListOfArgsElementsAreArgumentMatcher(sut);
+    Assert.isTrue(positive);
+    Assert.isFalse(negative);
   }
 
   @isTest
-  static void whenOfListIsCalledWithNull_listOfArgsIsEmpty() {
+  static void whenOfListIsCalledWithNull_matchesEmptyList() {
     // Act
-    final Params result = Params.ofList(null);
+    final Params sut = Params.ofList(null);
+
+    // Act
+    final Boolean result = sut.matches(new List<Object>());
 
     // Assert
-    System.assertEquals(0, result.listOfArgs.size());
+    Assert.isTrue(result);
   }
 
-  static void assertListOfArgsElementsAreArgumentMatcher(final Params params) {
-    for (Object argument : params.listOfArgs) {
-      System.assert(argument instanceof ArgumentMatcher);
-    }
-  }
-
-  class CustomMatcher implements ArgumentMatcher {
+  class CustomMatcher implements Matcher.ArgumentMatcher {
     public Boolean matches(Object callArgument) {
       return true;
     }

--- a/force-app/classes/test/ParamsTest.cls
+++ b/force-app/classes/test/ParamsTest.cls
@@ -13,9 +13,11 @@ private class ParamsTest {
 
     // Act
     sut = Params.empty();
+    // TODO match stuff and assert the result
+    final Boolean result = sut.matches(new List<Object>());
 
     // Assert
-    System.assertEquals(0, sut.listOfArgs.size());
+    System.assertEquals(true, result);
   }
 
   @isTest

--- a/force-app/classes/test/functional/FunctionalTest.cls
+++ b/force-app/classes/test/functional/FunctionalTest.cls
@@ -56,7 +56,7 @@ private class FunctionalTest {
       sut.createNewCompany(1000000000);
 
       // Assert
-      System.assert(false, 'We should not reach this statement');
+      Assert.fail('it shoud not reach this line');
     } catch (DmlException dex) {
       Assertions.assertThat(insertSObjectSpy).hasBeenCalledWith(Params.of(new Account(NumberOfEmployees = 1000000000)));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Migrate `matches` implementation from
- `ParameterizedMethodSpyCall` class
- `hasBeenLastCalledWith` method, 
- `hasBeenCalledWith` method
to `Params` class

Make `ArgumentMatcher` interface part of the `Matcher` class

Migrate `System.assert*` to `Assert.*` methods

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improve maintainability by centralizing the matching algorithm

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
