### PR TITLE
feat: improve configuration error messages

### DIFF
--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -86,25 +86,7 @@ public class MethodSpy {
       throw this.exceptionToThrow;
     }
 
-    throw buildStubConfigurationException(this.parameterizedMethodCalls, params, this.methodName);
-  }
-
-  private static Exception buildStubConfigurationException(
-    final List<ParameterizedMethodSpyCall> parameterizedMethodCalls,
-    final List<Object> params,
-    final String methodName
-  ) {
-    List<String> errorMessages = new List<String>();
-    for (ParameterizedMethodSpyCall parameterizedCall : parameterizedMethodCalls) {
-      errorMessages.add(parameterizedCall.toString());
-    }
-    return new IllegalArgumentException(
-      methodName +
-      ': No stub value found for a call with params ' +
-      params +
-      '\nHere are the configured stubs:\n\t' +
-      String.join(errorMessages, '\n\t')
-    );
+    throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallParams(params).build();
   }
 
   public void returns(Object value) {
@@ -206,5 +188,38 @@ public class MethodSpy {
     public override String toString() {
       return 'whenCalledWith' + this.paramsMatcher + '' + (this.shouldThrow() ? '.thenThrow(' + this.error + ')' : '.thenReturn(' + this.value + ')');
     }
+  }
+
+  private class ConfigurationExceptionBuilder {
+    private MethodSpy spy;
+    private List<Object> callParams;
+    private String methodName;
+
+    public ConfigurationExceptionBuilder withMethodSpy(final MethodSpy spy) {
+      this.spy = spy;
+      return this;
+    }
+
+    public ConfigurationExceptionBuilder withCallParams(final List<Object> callParams) {
+      this.callParams = callParams;
+      return this;
+    }
+
+    public ConfigurationException build() {
+      List<String> errorMessages = new List<String>();
+      for (ParameterizedMethodSpyCall parameterizedCall : this.spy.parameterizedMethodCalls) {
+        errorMessages.add(parameterizedCall.toString());
+      }
+      return new ConfigurationException(
+        this.spy.methodName +
+        ': No stub value found for a call with params ' +
+        this.callParams +
+        '\nHere are the configured stubs:\n\t' +
+        String.join(errorMessages, '\n\t')
+      );
+    }
+  }
+
+  public class ConfigurationException extends Exception {
   }
 }

--- a/force-app/classes/src/MethodSpy.cls
+++ b/force-app/classes/src/MethodSpy.cls
@@ -86,7 +86,25 @@ public class MethodSpy {
       throw this.exceptionToThrow;
     }
 
-    throw new IllegalArgumentException(this.methodName + ': No stub value found for a call with params ' + params);
+    throw buildStubConfigurationException(this.parameterizedMethodCalls, params, this.methodName);
+  }
+
+  private static Exception buildStubConfigurationException(
+    final List<ParameterizedMethodSpyCall> parameterizedMethodCalls,
+    final List<Object> params,
+    final String methodName
+  ) {
+    List<String> errorMessages = new List<String>();
+    for (ParameterizedMethodSpyCall parameterizedCall : parameterizedMethodCalls) {
+      errorMessages.add(parameterizedCall.toString());
+    }
+    return new IllegalArgumentException(
+      methodName +
+      ': No stub value found for a call with params ' +
+      params +
+      '\nHere are the configured stubs:\n\t' +
+      String.join(errorMessages, '\n\t')
+    );
   }
 
   public void returns(Object value) {
@@ -183,6 +201,10 @@ public class MethodSpy {
 
     public boolean matches(final List<Object> callArguments) {
       return this.paramsMatcher.matches(callArguments);
+    }
+
+    public override String toString() {
+      return 'whenCalledWith' + this.paramsMatcher + '' + (this.shouldThrow() ? '.thenThrow(' + this.error + ')' : '.thenReturn(' + this.value + ')');
     }
   }
 }

--- a/force-app/classes/src/Params.cls
+++ b/force-app/classes/src/Params.cls
@@ -38,7 +38,7 @@ public class Params {
   }
 
   public override String toString() {
-    return '[' + listOfArgs + ']';
+    return listOfArgs + '';
   }
 
   public static Params empty() {

--- a/force-app/classes/test/AssertionsTest.cls
+++ b/force-app/classes/test/AssertionsTest.cls
@@ -66,7 +66,7 @@ private class AssertionsTest {
     // Assert
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not called with [(Account:{})]', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not called with (Account:{})', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -82,7 +82,7 @@ private class AssertionsTest {
     // Assert
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not called with [(Account:{}, Opportunity:{})]', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not called with (Account:{}, Opportunity:{})', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -98,7 +98,7 @@ private class AssertionsTest {
     // Assert
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not called with [(Account:{}, test)]', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not called with (Account:{}, test)', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -114,7 +114,7 @@ private class AssertionsTest {
     // Assert
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not called with [()]', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not called with ()', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -147,7 +147,7 @@ private class AssertionsTest {
 
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not called with [(null)]\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not called with (null)\nmethod call history:\n\t#1 method(())\n', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -163,7 +163,7 @@ private class AssertionsTest {
     // Assert
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not last called with [(null)]', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not last called with (null)', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -179,7 +179,7 @@ private class AssertionsTest {
     // Assert
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not last called with [(Account:{})]', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not last called with (Account:{})', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -195,7 +195,7 @@ private class AssertionsTest {
     // Assert
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not last called with [(Account:{}, test)]', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not last called with (Account:{}, test)', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -211,7 +211,7 @@ private class AssertionsTest {
     // Assert
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not last called with [(null)]', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not last called with (null)', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -244,7 +244,7 @@ private class AssertionsTest {
 
     Assert.areEqual(2, fakeAsserter.callCount);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not last called with [(null)]\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not last called with (null)\nmethod call history:\n\t#1 method(())\n', fakeAsserter.errorMessage);
   }
 
   @isTest
@@ -261,11 +261,11 @@ private class AssertionsTest {
 
     sut.hasBeenCalledTimes(0);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not called 0 times\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not called 0 times\nmethod call history:\n\t#1 method(())\n', fakeAsserter.errorMessage);
 
     sut.hasBeenCalledTimes(2);
     Assert.isTrue(fakeAsserter.failed);
-    Assert.areEqual('Method method was not called 2 times\nmethod call history:\n\t#1 method([()])\n', fakeAsserter.errorMessage);
+    Assert.areEqual('Method method was not called 2 times\nmethod call history:\n\t#1 method(())\n', fakeAsserter.errorMessage);
   }
 
   @isTest

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -133,7 +133,7 @@ private class MethodSpyTest {
 
       // Assert
       Assert.fail('it shoud not reach this line');
-    } catch (IllegalArgumentException iaex) {
+    } catch (MethodSpy.ConfigurationException cex) {
       final Params expectedArgs = Params.of('param', new Account(Name = 'Test'), Matcher.any());
       Assert.areEqual(false, sut.hasBeenCalledWith(expectedArgs));
     }
@@ -151,7 +151,7 @@ private class MethodSpyTest {
 
       // Assert
       Assert.fail('it shoud not reach this line');
-    } catch (IllegalArgumentException iaex) {
+    } catch (MethodSpy.ConfigurationException cex) {
       Params expectedArgs = Params.of('param', new Account(Name = 'Test'));
       Assert.areEqual(false, sut.hasBeenCalledWith(expectedArgs));
     }
@@ -338,7 +338,7 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyConfiguredOnceToReturnOnMatchingTypeMatcher_whenCallingTheSpyWithWWrong_itShouldThrowIllegalArgumentException() {
+  static void givenSpyConfiguredOnceToReturnOnMatchingTypeMatcher_whenCallingTheSpyWithWWrong_itShouldThrowMethodSpyConfigurationException() {
     // Arrange
     final MethodSpy sut = new MethodSpy('methodName');
     sut.whenCalledWith(Params.of(Matcher.ofType(Account.getSObjectType()))).thenReturn('Expected Result');
@@ -349,7 +349,7 @@ private class MethodSpyTest {
       // Assert
       Assert.fail('it shoud not reach this line');
     } catch (Exception ex) {
-      Assert.isInstanceOfType(ex, IllegalArgumentException.class, 'Exception should be IllegalArgumentException');
+      Assert.isInstanceOfType(ex, MethodSpy.ConfigurationException.class, 'Exception should be MethodSpy.ConfigurationException');
     }
   }
 
@@ -382,7 +382,7 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyConfiguredOnceToReturnOnMatchingParams_whenCallingTheSpyWithOtherParams_itThrowsIllegalArgumentException() {
+  static void givenSpyConfiguredOnceToReturnOnMatchingParams_whenCallingTheSpyWithOtherParams_itThrowsMethodSpyConfigurationException() {
     // Arrange
     final MethodSpy sut = new MethodSpy('methodName');
     sut.whenCalledWith(Params.of('Another Param', true)).thenReturn('Expected Result');
@@ -392,11 +392,11 @@ private class MethodSpyTest {
       // Act
       sut.call(new List<Object>{ 'Another Param', false });
       Assert.fail('it shoud not reach this line');
-    } catch (IllegalArgumentException e) {
+    } catch (MethodSpy.ConfigurationException cex) {
       // Assert
       Assert.areEqual(
         'methodName: No stub value found for a call with params (Another Param, false)\nHere are the configured stubs:\n\twhenCalledWith(Another Param, true).thenReturn(Expected Result)\n\twhenCalledWith(Expected First Param, false).thenReturn(Another expected Result)\n\twhenCalledWith(Expected First Param, true).thenReturn(Yet another expected Result)',
-        e.getMessage()
+        cex.getMessage()
       );
 
       // TODO here
@@ -626,8 +626,8 @@ private class MethodSpyTest {
 
       // Assert
       Assert.fail('it should not reach this line');
-    } catch (IllegalArgumentException ex) {
-      Assert.isNotNull(ex, 'exception should be thrown');
+    } catch (MethodSpy.ConfigurationException cex) {
+      Assert.isNotNull(cex, 'exception should be thrown');
     }
   }
 

--- a/force-app/classes/test/MethodSpyTest.cls
+++ b/force-app/classes/test/MethodSpyTest.cls
@@ -385,14 +385,21 @@ private class MethodSpyTest {
   static void givenSpyConfiguredOnceToReturnOnMatchingParams_whenCallingTheSpyWithOtherParams_itThrowsIllegalArgumentException() {
     // Arrange
     final MethodSpy sut = new MethodSpy('methodName');
-    sut.whenCalledWith(Params.of('Expected First Param', true)).thenReturn('Expected Result');
+    sut.whenCalledWith(Params.of('Another Param', true)).thenReturn('Expected Result');
+    sut.whenCalledWith(Params.of('Expected First Param', false)).thenReturn('Another expected Result');
+    sut.whenCalledWith(Params.of('Expected First Param', true)).thenReturn('Yet another expected Result');
     try {
       // Act
       sut.call(new List<Object>{ 'Another Param', false });
       Assert.fail('it shoud not reach this line');
     } catch (IllegalArgumentException e) {
       // Assert
-      Assert.areEqual('methodName: No stub value found for a call with params (Another Param, false)', e.getMessage());
+      Assert.areEqual(
+        'methodName: No stub value found for a call with params (Another Param, false)\nHere are the configured stubs:\n\twhenCalledWith(Another Param, true).thenReturn(Expected Result)\n\twhenCalledWith(Expected First Param, false).thenReturn(Another expected Result)\n\twhenCalledWith(Expected First Param, true).thenReturn(Yet another expected Result)',
+        e.getMessage()
+      );
+
+      // TODO here
     }
   }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Improve error message format for spy configuration exception

Here is the new format: 
```
<spy.methodName>: No stub value found for a call with params <actual call params>
Here are the configured stubs:
	whenCalledWith(<params matcher>).thenReturn(<configured result>) | .thenThrow(<configured throw>)
	... same for other stub configuration
```
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improve developer experience
Being able to investigate how the stubs are configured and compare those configuration with the call params in order to detect potential configuration issue easily

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit test
Functional test
