### PR TITLE
refactor: migrate `hasBeen*` APIs from `MethodSpy` to `Assertions`

### DIFF
--- a/force-app/src/classes/Assertions.cls
+++ b/force-app/src/classes/Assertions.cls
@@ -40,7 +40,7 @@ public class Assertions {
     /**
      * Assert that a method spy has been lastly called with matching parameters
      *
-     * @param params params that should match last call paramters
+     * @param params params that should match last call parameters
      * @see          Params
      */
     void hasBeenLastCalledWith();
@@ -112,15 +112,15 @@ public class Assertions {
     }
 
     public void hasNotBeenCalled() {
-      this.asserter.isFalse(this.spy.hasBeenCalled(), buildErrorMessage(this.spy, ErrorMessageType.CALLED));
+      this.asserter.isTrue(this.spy.callLog.isEmpty(), buildErrorMessage(this.spy, ErrorMessageType.CALLED));
     }
 
     public void hasBeenCalled() {
-      this.asserter.isTrue(this.spy.hasBeenCalled(), buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED));
+      this.asserter.isFalse(this.spy.callLog.isEmpty(), buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED));
     }
 
     public void hasBeenCalledTimes(final Integer count) {
-      this.asserter.isTrue(this.spy.hasBeenCalledTimes(count), buildErrorMessage(this.spy, ErrorMessageType.NOT_CALLED_TIMES, count));
+      this.asserter.isTrue(this.spy.callLog.size() == count, buildErrorMessage(this.spy, ErrorMessageType.NOT_CALLED_TIMES, count));
     }
 
     public void hasBeenCalledWith() {
@@ -148,8 +148,15 @@ public class Assertions {
     }
 
     private void hasBeenCalledWithParams(final Params params) {
-      this.asserter.isTrue(this.spy.hasBeenCalled(), buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED));
-      this.asserter.isTrue(this.spy.hasBeenCalledWith(params), buildErrorMessage(this.spy, ErrorMessageType.NOT_CALLED_WITH, params));
+      Boolean hasBeenCalledWithParams = false;
+      for (Integer i = 0; i < this.spy.callLog.size(); ++i) {
+        if (params?.matches(this.spy.callLog.get(i))) {
+          hasBeenCalledWithParams = true;
+          break;
+        }
+      }
+      this.asserter.isFalse(this.spy.callLog.isEmpty(), buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED));
+      this.asserter.isTrue(hasBeenCalledWithParams, buildErrorMessage(this.spy, ErrorMessageType.NOT_CALLED_WITH, params));
     }
 
     public void hasBeenLastCalledWith() {
@@ -177,8 +184,8 @@ public class Assertions {
     }
 
     private void hasBeenLastCalledWithParams(final Params params) {
-      this.asserter.isTrue(this.spy.hasBeenCalled(), buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED));
-      this.asserter.isTrue(this.spy.hasBeenLastCalledWith(params), buildErrorMessage(this.spy, ErrorMessageType.NOT_LAST_CALLED_WITH, params));
+      this.asserter.isFalse(this.spy.callLog.isEmpty(), buildErrorMessage(this.spy, ErrorMessageType.NEVER_CALLED));
+      this.asserter.isTrue(params?.matches(this.spy.callLog.getLast()), buildErrorMessage(this.spy, ErrorMessageType.NOT_LAST_CALLED_WITH, params));
     }
   }
 
@@ -229,17 +236,21 @@ public class Assertions {
     }
 
     private List<ErrorMessageRow> buildCallTraces(MethodSpy spy) {
-      final List<Params> callLogParams = spy.getCallLogParams();
-      if (callLogParams.isEmpty()) {
+      final List<Params> reversedCallLogParams = new List<Params>();
+      for (Integer i = this.spy.callLog.size() - 1; i >= 0; i--) {
+        reversedCallLogParams.add(Params.ofList(this.spy.callLog.get(i)));
+      }
+
+      if (reversedCallLogParams.isEmpty()) {
         return new List<ErrorMessageRow>();
       }
 
       final List<ErrorMessageRow> rows = new List<ErrorMessageRow>();
       rows.add(new ErrorMessageRow('method call history:'));
       final String template = '#{0} {1}({2})';
-      for (Integer i = 0; i < callLogParams.size(); i++) {
-        final Params params = callLogParams[i];
-        final Integer count = callLogParams.size() - i;
+      for (Integer i = 0; i < reversedCallLogParams.size(); i++) {
+        final Params params = reversedCallLogParams[i];
+        final Integer count = reversedCallLogParams.size() - i;
         rows.add(new ErrorMessageRow(String.format(template, new List<Object>{ count, spy.methodName, params }), true));
       }
       return rows;

--- a/force-app/src/classes/Assertions.cls
+++ b/force-app/src/classes/Assertions.cls
@@ -84,11 +84,17 @@ public class Assertions {
   @TestVisible
   private class MethodSpyAsserter implements Asserter {
     public void isTrue(Boolean value, ErrorMessage message) {
+      // Do not use Assert.isTrue to check value
+      // Because we want to compute ErrorMessage to string()
+      // only when the Boolean is false
       if (!value) {
         Assert.fail(message.toString());
       }
     }
     public void isFalse(Boolean value, ErrorMessage message) {
+      // Do not use Assert.isFalse to check value
+      // Because we want to compute ErrorMessage to string()
+      // only when the Boolean is true
       if (value) {
         Assert.fail(message.toString());
       }

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -29,49 +29,6 @@ public class MethodSpy {
     this.callLog = new CallLog();
   }
 
-  public Boolean hasBeenCalled() {
-    return !this.callLog.isEmpty();
-  }
-
-  public Boolean hasBeenCalledWith() {
-    return this.hasBeenCalledWith(Params.empty());
-  }
-
-  public Boolean hasBeenCalledWith(final Params params) {
-    if (params == null) {
-      throw new Matcher.MatcherException('Params cannot be null');
-    }
-    final Iterator<MethodCall> it = this.callLog.iterator();
-    while (it.hasNext()) {
-      final List<Object> objectParams = it.next().params;
-      if (params.matches(objectParams) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  public Boolean hasBeenLastCalledWith() {
-    return this.hasBeenLastCalledWith(Params.empty());
-  }
-
-  public Boolean hasBeenLastCalledWith(final Params params) {
-    if (params == null) {
-      throw new Matcher.MatcherException('Params cannot be null');
-    }
-    if (this.callLog.isEmpty()) {
-      return false;
-    }
-
-    final List<Object> actualListOfArgs = this.callLog.getLast();
-    return params.matches(actualListOfArgs);
-  }
-
-  public Boolean hasBeenCalledTimes(final Integer count) {
-    return this.callLog.size() == count;
-  }
-
   public Object call(List<Object> params) {
     this.callLog.add(new MethodCall(params));
 

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -17,7 +17,7 @@
 @IsTest
 public class MethodSpy {
   public String methodName { get; private set; }
-  private CallLog callLog;
+  public CallLog callLog { get; private set; }
   private List<ParameterizedMethodSpyCall> parameterizedMethodCalls = new List<ParameterizedMethodSpyCall>();
   private Object returnValue;
   private Boolean configuredGlobalReturn = false;
@@ -43,7 +43,8 @@ public class MethodSpy {
     }
     final Iterator<MethodCall> it = this.callLog.iterator();
     while (it.hasNext()) {
-      if (params.matches(it.next().params)) {
+      final List<Object> objectParams = it.next().params;
+      if (params.matches(objectParams) {
         return true;
       }
     }
@@ -143,20 +144,10 @@ public class MethodSpy {
     return parameterizedMethodCall;
   }
 
-  public List<Params> getCallLogParams() {
-    final List<Params> reversedCallsTrace = new List<Params>();
-    final List<MethodCall> calls = this.callLog.callParams;
-    for (Integer i = calls.size() - 1; i >= 0; i--) {
-      final MethodCall call = calls[i];
-      reversedCallsTrace.add(Params.ofList(call.params));
-    }
-    return reversedCallsTrace;
-  }
-
-  private class CallLog implements Iterable<MethodCall> {
+  public class CallLog {
     private List<MethodCall> callParams = new List<MethodCall>();
 
-    public void add(MethodCall callParam) {
+    private void add(MethodCall callParam) {
       this.callParams.add(callParam);
     }
 
@@ -173,11 +164,7 @@ public class MethodSpy {
     }
 
     public List<Object> getLast() {
-      return this.get(this.size() - 1);
-    }
-
-    public Iterator<MethodCall> iterator() {
-      return this.callParams.iterator();
+      return this.size() > 0 ? this.get(this.size() - 1) : null;
     }
   }
 

--- a/force-app/test/classes/unit/MethodSpyTest.cls
+++ b/force-app/test/classes/unit/MethodSpyTest.cls
@@ -24,72 +24,6 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyNotCalled_hasBeenCalledWithNull_itThrowsMatcherException() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-
-    try {
-      // Act
-      sut.hasBeenCalledWith(null);
-
-      // Assert
-      Assert.fail('Expected exception was not thrown');
-    } catch (Exception ex) {
-      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
-    }
-  }
-
-  @IsTest
-  static void givenSpyCalled_hasBeenCalledWithNull_itThrowsMatcherException() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.call(new List<Object>());
-
-    try {
-      // Act
-      sut.hasBeenCalledWith(null);
-
-      // Assert
-      Assert.fail('Expected exception was not thrown');
-    } catch (Exception ex) {
-      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
-    }
-  }
-
-  @IsTest
-  static void givenSpyNotCalled_hasBeenLastCalledWithNull_itThrowsMatcherException() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-
-    try {
-      // Act
-      sut.hasBeenLastCalledWith(null);
-
-      // Assert
-      Assert.fail('Expected exception was not thrown');
-    } catch (Exception ex) {
-      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
-    }
-  }
-
-  @IsTest
-  static void givenSpyCalled_hasBeenLastCalledWithNull_itThrowsMatcherException() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.call(new List<Object>());
-
-    try {
-      // Act
-      sut.hasBeenLastCalledWith(null);
-
-      // Assert
-      Assert.fail('Expected exception was not thrown');
-    } catch (Exception ex) {
-      Assert.isInstanceOfType(ex, Matcher.MatcherException.class);
-    }
-  }
-
-  @IsTest
   static void givenSpyConfiguredWithParams_whenCalledWithMatching_spyIsCalled() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
@@ -100,8 +34,6 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith(Params.of('param')));
-    Assert.areEqual(true, sut.hasBeenLastCalledWith(Params.of('param')));
   }
 
   @IsTest
@@ -115,8 +47,6 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith());
-    Assert.areEqual(true, sut.hasBeenLastCalledWith());
   }
 
   @IsTest
@@ -130,8 +60,6 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith(Params.empty()));
-    Assert.areEqual(true, sut.hasBeenLastCalledWith(Params.empty()));
   }
 
   @IsTest
@@ -145,8 +73,6 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith(Params.of('2', 'params')));
-    Assert.areEqual(true, sut.hasBeenLastCalledWith(Params.of('2', 'params')));
   }
 
   @IsTest
@@ -160,8 +86,6 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith(Params.of('3', 'params', 'test')));
-    Assert.areEqual(true, sut.hasBeenLastCalledWith(Params.of('3', 'params', 'test')));
   }
 
   @IsTest
@@ -175,8 +99,6 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith(Params.of('test', 'with', '4', 'params')));
-    Assert.areEqual(true, sut.hasBeenLastCalledWith(Params.of('test', 'with', '4', 'params')));
   }
 
   @IsTest
@@ -190,8 +112,6 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith(Params.of('another', 'test', 'with', '5', 'params')));
-    Assert.areEqual(true, sut.hasBeenLastCalledWith(Params.of('another', 'test', 'with', '5', 'params')));
   }
 
   @IsTest
@@ -206,9 +126,6 @@ private class MethodSpyTest {
     // Assert
     Params expectedArgs = Params.of('param', new Account(Name = 'Test'), Matcher.any());
     Assert.areEqual('Expected Result', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith(expectedArgs));
-    Assert.areEqual(false, sut.hasBeenLastCalledWith(Params.empty()));
-    Assert.areEqual(true, sut.hasBeenLastCalledWith(expectedArgs));
   }
 
   @IsTest
@@ -224,9 +141,8 @@ private class MethodSpyTest {
 
       // Assert
       Assert.fail('it shoud not reach this line');
-    } catch (MethodSpy.ConfigurationException cex) {
-      Params expectedArgs = Params.of('param', new Account(Name = 'Test'), Matcher.any());
-      Assert.areEqual(false, sut.hasBeenCalledWith(expectedArgs));
+    } catch (Exception ex) {
+      Assert.isInstanceOfType(ex, MethodSpy.ConfigurationException.class);
     }
   }
 
@@ -242,9 +158,8 @@ private class MethodSpyTest {
 
       // Assert
       Assert.fail('it shoud not reach this line');
-    } catch (MethodSpy.ConfigurationException cex) {
-      Params expectedArgs = Params.of('param', new Account(Name = 'Test'));
-      Assert.areEqual(false, sut.hasBeenCalledWith(expectedArgs));
+    } catch (Exception ex) {
+      Assert.isInstanceOfType(ex, MethodSpy.ConfigurationException.class);
     }
   }
 
@@ -260,9 +175,6 @@ private class MethodSpyTest {
     // Assert
     Params expectedArgs = Params.of(Matcher.jsonEquals(new List<String>{ 'test' }), Matcher.ofType(Account.getSObjectType()), Matcher.any());
     Assert.areEqual('Expected Result', result);
-    Assert.areEqual(true, sut.hasBeenCalledWith(expectedArgs));
-    Assert.areEqual(false, sut.hasBeenLastCalledWith(Params.empty()));
-    Assert.areEqual(true, sut.hasBeenLastCalledWith(expectedArgs));
   }
 
   @IsTest
@@ -524,194 +436,7 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyNotCalled_hasBeenCalled_itReturnsFalse() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.returns('any result');
-
-    // Act
-    Boolean hasBeenCalled = sut.hasBeenCalled();
-
-    // Assert
-    Assert.isFalse(hasBeenCalled);
-  }
-
-  @IsTest
-  static void givenSpyCalled_hasBeenCalled_itReturnsTrue() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.returns('any result');
-    sut.call(new List<Object>{});
-
-    // Act
-    Boolean hasBeenCalled = sut.hasBeenCalled();
-
-    // Assert
-    Assert.isTrue(hasBeenCalled);
-  }
-
-  @IsTest
-  static void givenSpyNotCalled_hasBeenCalledTimes_itReturnsTrueForZero() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.returns('any result');
-
-    // Act && Assert
-    Assert.isFalse(sut.hasBeenCalledTimes(-1));
-    Assert.isTrue(sut.hasBeenCalledTimes(0));
-    Assert.isFalse(sut.hasBeenCalledTimes(1));
-    Assert.isFalse(sut.hasBeenCalledTimes(5));
-  }
-
-  @IsTest
-  static void givenSpyCalledOnce_hasBeenCalledTimes_itReturnsTrueForOne() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.returns('any result');
-    sut.call(new List<Object>{});
-
-    // Act && Assert
-    Assert.isFalse(sut.hasBeenCalledTimes(-1));
-    Assert.isFalse(sut.hasBeenCalledTimes(0));
-    Assert.isTrue(sut.hasBeenCalledTimes(1));
-    Assert.isFalse(sut.hasBeenCalledTimes(5));
-  }
-
-  @IsTest
-  static void givenSpyCalledFiveTimes_hasBeenCalledTimes_itReturnsTrueForFive() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.returns('any result');
-    sut.call(new List<Object>{});
-    sut.call(new List<Object>{});
-    sut.call(new List<Object>{});
-    sut.call(new List<Object>{});
-    sut.call(new List<Object>{});
-
-    // Act && Assert
-    Assert.isFalse(sut.hasBeenCalledTimes(-1));
-    Assert.isFalse(sut.hasBeenCalledTimes(0));
-    Assert.isFalse(sut.hasBeenCalledTimes(1));
-    Assert.isTrue(sut.hasBeenCalledTimes(5));
-    Assert.isFalse(sut.hasBeenCalledTimes(6));
-  }
-
-  @IsTest
-  static void givenSpyCalledLastWithParams_hasBeenLastCalledWithParams_returnsTrueForLastAndFalseElse() {
-    // Arrange
-    List<Object> first = new List<Object>{ new Opportunity() };
-    List<Object> last = new List<Object>{ new Account() };
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.call(first);
-    sut.call(last);
-
-    // Act && Assert
-    Assert.isFalse(sut.hasBeenLastCalledWith(Params.of(new Opportunity())));
-    Assert.isTrue(sut.hasBeenLastCalledWith(Params.of(new Account())));
-  }
-
-  @IsTest
-  static void givenSpyCalledLastWithoutParams_hasBeenLastCalledWithoutArgs_returnsMatches() {
-    // Arrange
-    List<Object> param = new List<Object>();
-    MethodSpy sut = new MethodSpy('methodName');
-
-    // Act & Assert
-    Assert.isFalse(sut.hasBeenLastCalledWith());
-    sut.call(param);
-    Assert.isTrue(sut.hasBeenLastCalledWith());
-  }
-
-  @IsTest
-  static void givenSpyCalledLastWithoutParams_hasBeenLastCalledWithEmptyArgs_returnsMatches() {
-    // Arrange
-    List<Object> param = new List<Object>();
-    MethodSpy sut = new MethodSpy('methodName');
-
-    // Act & Assert
-    Assert.isFalse(sut.hasBeenLastCalledWith(Params.empty()));
-    sut.call(param);
-    Assert.isTrue(sut.hasBeenLastCalledWith(Params.empty()));
-  }
-
-  @IsTest
-  static void givenSpyCalledLastWithParams_hasBeenLastCalledWithMatchers_returnsMatches() {
-    // Arrange
-    Object param = new Account();
-    MethodSpy sut = new MethodSpy('methodName');
-
-    // Act & Assert
-    Assert.isFalse(sut.hasBeenLastCalledWith(Params.of(Matcher.any())));
-    sut.call(new List<Object>{ param });
-    Assert.isTrue(sut.hasBeenLastCalledWith(Params.of(Matcher.any())));
-  }
-
-  @IsTest
-  static void givenSpyCalledMultipleTimes_hasBeenCalledWith_returnsTrueForCalledParamsElseFalse() {
-    // Arrange
-    List<Object> first = new List<Object>{ new Opportunity() };
-    List<Object> last = new List<Object>{ new Account() };
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.call(first);
-    sut.call(last);
-
-    // Act && Assert
-
-    Assert.isTrue(sut.hasBeenCalledWith(Params.of(new Opportunity())));
-    Assert.isTrue(sut.hasBeenCalledWith(Params.of(new Account())));
-    Assert.isFalse(sut.hasBeenCalledWith(Params.of(new Case())));
-  }
-
-  @IsTest
-  static void givenSpyCalledWithoutParams_hasBeenCalledWithoutArgs_returnsMatches() {
-    // Arrange
-    List<Object> param = new List<Object>();
-    MethodSpy sut = new MethodSpy('methodName');
-
-    // Act & Assert
-    Assert.isFalse(sut.hasBeenCalledWith());
-    sut.call(param);
-    Assert.isTrue(sut.hasBeenCalledWith());
-  }
-
-  @IsTest
-  static void givenSpyCalledWithoutParams_hasBeenCalledEmptyArgs_returnsMatches() {
-    // Arrange
-    List<Object> param = new List<Object>();
-    MethodSpy sut = new MethodSpy('methodName');
-
-    // Act & Assert
-    Assert.isFalse(sut.hasBeenCalledWith(Params.empty()));
-    sut.call(param);
-    Assert.isTrue(sut.hasBeenCalledWith(Params.empty()));
-  }
-
-  @IsTest
-  static void givenSpyCalledWithParams_hasBeenCalledWithMatcher_returnsMatches() {
-    // Arrange
-    Object param = new Account(Name = 'test');
-    MethodSpy sut = new MethodSpy('methodName');
-
-    // Act & Assert
-    Assert.isFalse(sut.hasBeenCalledWith(Params.of(Matcher.any())));
-    sut.call(new List<Object>{ param });
-    Assert.isTrue(sut.hasBeenCalledWith(Params.of(Matcher.any())));
-  }
-
-  @IsTest
-  static void givenSpyCalledWithParam_hasBeenCalledWithJSONMatcher() {
-    // Arrange
-    Object param = new Account(Name = 'test');
-    MethodSpy sut = new MethodSpy('methodName');
-
-    // Act & Assert
-    Assert.isFalse(sut.hasBeenCalledWith(Params.of(Matcher.jsonEquals(param))));
-    sut.call(new List<Object>{ param });
-    Assert.isTrue(sut.hasBeenCalledWith(Params.of(Matcher.jsonEquals(param))));
-  }
-
-  @IsTest
-  static void givenSpyCalledWithCustomApex_hasBeenCalledWithReturnsTrue() {
+  static void givenSpyConfiguredWithCustomApex_whenCalledWith_returnsConfiguredValue() {
     // Arrange
     CustomApex param = new CustomApex('test');
     MethodSpy sut = new MethodSpy('methodName');
@@ -726,7 +451,7 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyCalledWithListOf2_hasBeenCalledWithListOf1ReturnsFalse() {
+  static void givenSpyConfiguredWithListOf2_whenCalledWithSomethingElses_throwsConfigurationException() {
     // Arrange
     List<Object> objects = new List<Object>{ new Account(), new Account() };
     MethodSpy sut = new MethodSpy('methodName');
@@ -744,7 +469,7 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyCalledWithCustomApexWithEquals_hasBeenCalledWithReturnsTrue() {
+  static void givenSpyConfiguredWithCustomApexWithEquals_whenCalledWith_returnsConfiguredValue() {
     // Arrange
     CustomApexWithEquals param = new CustomApexWithEquals('test');
     MethodSpy sut = new MethodSpy('methodName');

--- a/force-app/test/classes/unit/MethodSpyTest.cls
+++ b/force-app/test/classes/unit/MethodSpyTest.cls
@@ -34,6 +34,7 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
+    Assert.areEqual(new List<Object>{ 'param' }, sut.callLog.getLast());
   }
 
   @IsTest
@@ -47,6 +48,7 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
+    Assert.areEqual(new List<Object>(), sut.callLog.getLast());
   }
 
   @IsTest
@@ -60,6 +62,7 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
+    Assert.areEqual(new List<Object>(), sut.callLog.getLast());
   }
 
   @IsTest
@@ -73,6 +76,7 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
+    Assert.areEqual(new List<Object>{ '2', 'params' }, sut.callLog.getLast());
   }
 
   @IsTest
@@ -86,6 +90,7 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
+    Assert.areEqual(new List<Object>{ '3', 'params', 'test' }, sut.callLog.getLast());
   }
 
   @IsTest
@@ -99,6 +104,7 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
+    Assert.areEqual(new List<Object>{ 'test', 'with', '4', 'params' }, sut.callLog.getLast());
   }
 
   @IsTest
@@ -112,6 +118,7 @@ private class MethodSpyTest {
 
     // Assert
     Assert.areEqual('test', result);
+    Assert.areEqual(new List<Object>{ 'another', 'test', 'with', '5', 'params' }, sut.callLog.getLast());
   }
 
   @IsTest
@@ -125,7 +132,7 @@ private class MethodSpyTest {
 
     // Assert
     Params expectedArgs = Params.of('param', new Account(Name = 'Test'), Matcher.any());
-    Assert.areEqual('Expected Result', result);
+    Assert.areEqual(new List<Object>{ 'param', new Account(Name = 'Test'), true }, sut.callLog.getLast());
   }
 
   @IsTest
@@ -143,6 +150,11 @@ private class MethodSpyTest {
       Assert.fail('it shoud not reach this line');
     } catch (Exception ex) {
       Assert.isInstanceOfType(ex, MethodSpy.ConfigurationException.class);
+      Assert.areNotEqual(
+        new List<Object>{ 'param', Matcher.equals('otherParam'), Matcher.jsonEquals(new Account(Name = 'Test')), Matcher.any(), Matcher.ofType('Integer') },
+        sut.callLog.getLast()
+      );
+      Assert.areEqual(new List<Object>{ 'param' }, sut.callLog.getLast());
     }
   }
 
@@ -160,6 +172,8 @@ private class MethodSpyTest {
       Assert.fail('it shoud not reach this line');
     } catch (Exception ex) {
       Assert.isInstanceOfType(ex, MethodSpy.ConfigurationException.class);
+      Assert.areNotEqual(new List<Object>{ 'param', new Account(Name = 'Test') }, sut.callLog.getLast());
+      Assert.areEqual(new List<Object>{ new Opportunity() }, sut.callLog.getLast());
     }
   }
 
@@ -175,6 +189,7 @@ private class MethodSpyTest {
     // Assert
     Params expectedArgs = Params.of(Matcher.jsonEquals(new List<String>{ 'test' }), Matcher.ofType(Account.getSObjectType()), Matcher.any());
     Assert.areEqual('Expected Result', result);
+    Assert.areEqual(new List<Object>{ new List<String>{ 'test' }, new Account(Name = 'random'), true }, sut.callLog.getLast());
   }
 
   @IsTest
@@ -187,7 +202,10 @@ private class MethodSpyTest {
     // Act && Assert
     Object firstCallResult = sut.call(new List<Object>{ new Account() });
     Assert.areEqual('Account result', firstCallResult);
+    Assert.areEqual(new List<Object>{ new Account() }, sut.callLog.getLast());
     Object secondCallResult = sut.call(new List<Object>{ new Opportunity() });
+    Assert.areEqual(new List<Object>{ new Account() }, sut.callLog.get(0));
+    Assert.areEqual(new List<Object>{ new Opportunity() }, sut.callLog.getLast());
     Assert.areEqual('Opportunity result', secondCallResult);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Refactor `hasBeen*` APIs from `MethodSpy
Migrate the implementations to `Assertions`

I needed to open `CallLog` and `MethodCall` type.
I used properties, so they can still be private to the `MethodSpy` type for manipulation

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Migrate redundant `hasBeen*` implementation from `MethodSpy` to `Assertions`.
Consumer use those `methods` from Assertions class so we don't to same API at different places (and related unit test)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Existing unit test to ensure spec is maintained

**Open Discussion:** should we had more black box testing for `hasBeen*` in `AssertionsTest` ?