### PR TITLE
fix: not usable unlocked package with namespace

### DIFF
--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -18,8 +18,15 @@ jobs:
       branch: main
     secrets: inherit
 
-  prepare-release:
+  validate-package-version:
+    uses: ./.github/workflows/validate-package-version.yml
     needs: create-package-version
+    with:
+      packageId: ${{ needs.create-package-version.outputs.packageId }}
+    secrets: inherit
+
+  prepare-release:
+    needs: validate-package-version
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -66,6 +66,13 @@ jobs:
       branch: pull-request
     secrets: inherit
 
+  validate-package-version:
+    uses: ./.github/workflows/validate-package-version.yml
+    needs: create-package-version
+    with:
+      packageId: ${{ needs.create-package-version.outputs.packageId }}
+    secrets: inherit
+
   commit-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -11,9 +11,16 @@ jobs:
       branch: main
     secrets: inherit
 
+  validate-package-version:
+    uses: ./.github/workflows/validate-package-version.yml
+    needs: create-package-version
+    with:
+      packageId: ${{ needs.create-package-version.outputs.packageId }}
+    secrets: inherit
+
   promote-package-version:
     runs-on: ubuntu-latest
-    needs: create-package-version
+    needs: [create-package-version, validate-package-version]
     steps:
       - name: Set environment variables
         run: |

--- a/.github/workflows/validate-package-version.yml
+++ b/.github/workflows/validate-package-version.yml
@@ -1,20 +1,15 @@
-name: create package version
+name: validate package version
 on:
   workflow_call:
     inputs:
-      branch:
-        required: true
-        type: string
-    outputs:
       packageId:
+        required: true
         description: 04t package version id created
-        value: ${{ jobs.create-package-version.outputs.packageId }}
+        type: string
 
 jobs:
-  create-package-version:
+  validate-package-version:
     runs-on: ubuntu-latest
-    outputs:
-      packageId: ${{ steps.create.outputs.packageId }}
     steps:
       - name: Set environment variables
         run: |
@@ -33,9 +28,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Create package version
-        id: create
-        run: |
-          packageId=$(sfdx force:package:version:create --definitionfile config/project-scratch-def.json --package "Apex Mockery" --branch "${{ inputs.branch }}" --tag ${{ github.sha }} --wait 120 --codecoverage --skipancestorcheck --installationkeybypass --json | jq -e -r ".result.SubscriberPackageVersionId")
-          echo "packageId=$packageId" >> $GITHUB_ENV
-          echo "packageId=$packageId" >> $GITHUB_OUTPUT
+      - name: Create scratch org
+        run: sfdx force:org:create -f config/project-scratch-def.json -a scratch-org -s -d 1
+
+      - name: Check package installation
+        run: sfdx force:package:install -p ${{ inputs.packageId }} -u scratch-org -w 10
+
+      - name: Deploy namespaced recipes
+        run: sfdx force:source:deploy -p force-app/recipes
+
+      - name: Execute tests
+        run: sfdx force:apex:test:run -r human -d ./tests/apex -l RunLocalTests -w 20
+
+      - name: Delete scratch org
+        if: always()
+        run: sfdx force:org:delete -p -u scratch-org

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ It returns a Mock instance containing the stub and all the mechanism to spy/conf
 Mock myMock = Mock.forType(MyType.class);
 ```
 
-Use the `MockFactory.forType` and `mockery` namespace when using the unlocked package package.
-Types to stub must call `Test.createStubs` from the [same namespace](<https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_testing_stub_api.htm#:~:text=The%20object%20being%20mocked%20must%20be%20in%20the%20same%20namespace%20as%20the%20call%20to%20the%20Test.createStub()%20method.%20However%2C%20the%20implementation%20of%20the%20StubProvider%20interface%20can%20be%20in%20another%20namespace>)
+Use the `MockFactory.forType` when using the lib from the unlocked package with namespaced code.
+To create `Mock`, put the `MockFactory` in the same namespace of the type you want to stub.
+If the code to stub is not namespaced then put the `MockFactory` code outside a namespace. Then use the lib.
+_Custom types to stub must call `Test.createStubs` from the [same namespace](<https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_testing_stub_api.htm#:~:text=The%20object%20being%20mocked%20must%20be%20in%20the%20same%20namespace%20as%20the%20call%20to%20the%20Test.createStub()%20method.%20However%2C%20the%20implementation%20of%20the%20StubProvider%20interface%20can%20be%20in%20another%20namespace>)_
 
 ```java
 mockery.Mock myMock = MockFactory.forType(MyType.class);

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Deploy via the deploy button
        src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
 </a>
 
-Or copy `force-app/src/classes` test classes in your sfdx project to deploy it with your favourite deployment methods
+Or copy `force-app/src/classes` apex classes in your sfdx project to deploy it with your favourite deployment methods
 
-Or you can deploy the library using our unlocked package from the [latest release](https://github.com/salesforce/apex-mockery/releases/latest)
+Or you can install the library using our unlocked package from the [latest release](https://github.com/salesforce/apex-mockery/releases/latest) and then deploy `force-app/recipes/classes/utils/MockFactory.cls` class or copy the `forType` method inside your own test utils class.
 
 ## Usage
 
@@ -78,6 +78,13 @@ It returns a Mock instance containing the stub and all the mechanism to spy/conf
 
 ```java
 Mock myMock = Mock.forType(MyType.class);
+```
+
+Use the `MockFactory.forType` and `mockery` namespace when using the unlocked package package.
+Types to stub must call `Test.createStubs` from the [same namespace](<https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_testing_stub_api.htm#:~:text=The%20object%20being%20mocked%20must%20be%20in%20the%20same%20namespace%20as%20the%20call%20to%20the%20Test.createStub()%20method.%20However%2C%20the%20implementation%20of%20the%20StubProvider%20interface%20can%20be%20in%20another%20namespace>)
+
+```java
+mockery.Mock myMock = MockFactory.forType(MyType.class);
 ```
 
 ### Stub
@@ -295,6 +302,8 @@ Matcher.equals(10);
 ```java
 Matcher.jsonEquals(new WithoutEqualsType(10, true, '...'));
 ```
+
+Custom types must add the `@JsonAccess` [annotation](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation_JsonAccess.htm) with `serializable='always' to the class when using the unlocked package version.
 
 #### ofType
 

--- a/force-app/recipes/classes/ApexMockeryOverview.cls
+++ b/force-app/recipes/classes/ApexMockeryOverview.cls
@@ -9,30 +9,30 @@ private class ApexMockeryOverview {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new Pastry('Chocolatine')).thenReturn(Date.today().addDays(3));
     planDeliverySpy.whenCalledWith(new OperaPastryMatcher()).thenThrow(new RecipeException());
     planDeliverySpy.returns(Date.today().addDays(4));
 
-    Assertions.assertThat(planDeliverySpy).hasNotBeenCalled();
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledTimes(0);
+    mockery.Assertions.assertThat(planDeliverySpy).hasNotBeenCalled();
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledTimes(0);
 
     // Act & Assert
     OrderConfirmation order = myBakery.order(new Pastry('Chocolatine'));
-    Assertions.assertThat(planDeliverySpy).hasBeenCalled();
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
-    Assertions.assertThat(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Chocolatine'));
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledTimes(1);
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalled();
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Chocolatine'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledTimes(1);
     Assert.areEqual(Date.today().addDays(3), order.deliveryDate);
 
     order = myBakery.order(new Pastry('Croissant'));
-    Assertions.assertThat(planDeliverySpy).hasBeenCalled();
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
-    Assertions.assertThat(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Croissant'));
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledTimes(2);
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalled();
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Croissant'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledTimes(2);
     Assert.areEqual(Date.today().addDays(4), order.deliveryDate);
 
     try {

--- a/force-app/recipes/classes/ApexMockeryOverview.cls
+++ b/force-app/recipes/classes/ApexMockeryOverview.cls
@@ -9,7 +9,7 @@ private class ApexMockeryOverview {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new Pastry('Chocolatine')).thenReturn(Date.today().addDays(3));

--- a/force-app/recipes/classes/OperaPastryMatcher.cls
+++ b/force-app/recipes/classes/OperaPastryMatcher.cls
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 @isTest
-public class OperaPastryMatcher implements Matcher.ArgumentMatcher {
+public class OperaPastryMatcher implements mockery.Matcher.ArgumentMatcher {
   public Boolean matches(Object callArgument) {
     Pastry p = (Pastry) callArgument;
     return p.name == 'Opera';

--- a/force-app/recipes/classes/Pastry.cls
+++ b/force-app/recipes/classes/Pastry.cls
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+@JsonAccess(serializable='always')
 public class Pastry {
   public String name;
 

--- a/force-app/recipes/classes/asserting/HasBeenCalled.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalled.cls
@@ -9,7 +9,7 @@ private class HasBeenCalled {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 

--- a/force-app/recipes/classes/asserting/HasBeenCalled.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalled.cls
@@ -9,14 +9,14 @@ private class HasBeenCalled {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 
     // Act
     myBakery.order(new Pastry('Chocolatine'));
 
     // Assert
-    Assertions.assertThat(planDeliverySpy).hasBeenCalled();
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalled();
   }
 }

--- a/force-app/recipes/classes/asserting/HasBeenCalledTimes.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledTimes.cls
@@ -9,8 +9,8 @@ private class HasBeenCalledTimes {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 
     // Act
@@ -18,6 +18,6 @@ private class HasBeenCalledTimes {
     myBakery.order(new Pastry('Croissant'));
 
     // Assert
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledTimes(2);
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledTimes(2);
   }
 }

--- a/force-app/recipes/classes/asserting/HasBeenCalledTimes.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledTimes.cls
@@ -9,7 +9,7 @@ private class HasBeenCalledTimes {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 

--- a/force-app/recipes/classes/asserting/HasBeenCalledWith.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWith.cls
@@ -9,7 +9,7 @@ private class HasBeenCalledWith {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 

--- a/force-app/recipes/classes/asserting/HasBeenCalledWith.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWith.cls
@@ -9,8 +9,8 @@ private class HasBeenCalledWith {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 
     // Act
@@ -18,7 +18,7 @@ private class HasBeenCalledWith {
     myBakery.order(new Pastry('Croissant'));
 
     // Assert
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
   }
 }

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithCustomMatcher.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithCustomMatcher.cls
@@ -9,7 +9,7 @@ private class HasBeenCalledWithCustomMatcher {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithCustomMatcher.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithCustomMatcher.cls
@@ -9,8 +9,8 @@ private class HasBeenCalledWithCustomMatcher {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 
     // Act
@@ -18,7 +18,7 @@ private class HasBeenCalledWithCustomMatcher {
     myBakery.order(new Pastry('Croissant'));
 
     // Assert
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new OperaPastryMatcher()); // Match not serializable types
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new OperaPastryMatcher()); // Match not serializable types
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
   }
 }

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithJSONMatcher.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithJSONMatcher.cls
@@ -9,7 +9,7 @@ private class HasBeenCalledWithJSONMatcher {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithJSONMatcher.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithJSONMatcher.cls
@@ -9,8 +9,8 @@ private class HasBeenCalledWithJSONMatcher {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 
     // Act
@@ -18,7 +18,7 @@ private class HasBeenCalledWithJSONMatcher {
     myBakery.order(new Pastry('Croissant'));
 
     // Assert
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(Matcher.jsonEquals(new Pastry('Chocolatine'))); // Match not serializable types
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(mockery.Matcher.jsonEquals(new Pastry('Chocolatine'))); // Match not serializable types
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
   }
 }

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithTypeMatcher.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithTypeMatcher.cls
@@ -9,7 +9,7 @@ private class HasBeenCalledWithTypeMatcher {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithTypeMatcher.cls
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithTypeMatcher.cls
@@ -9,8 +9,8 @@ private class HasBeenCalledWithTypeMatcher {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 
     // Act
@@ -18,7 +18,7 @@ private class HasBeenCalledWithTypeMatcher {
     myBakery.order(new Pastry('Croissant'));
 
     // Assert
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(Matcher.ofType(Pastry.class));
-    Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(mockery.Matcher.ofType(Pastry.class));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
   }
 }

--- a/force-app/recipes/classes/asserting/HasBeenLastCalledWith.cls
+++ b/force-app/recipes/classes/asserting/HasBeenLastCalledWith.cls
@@ -9,7 +9,7 @@ private class HasBeenLastCalledWith {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 

--- a/force-app/recipes/classes/asserting/HasBeenLastCalledWith.cls
+++ b/force-app/recipes/classes/asserting/HasBeenLastCalledWith.cls
@@ -9,8 +9,8 @@ private class HasBeenLastCalledWith {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 
     // Act
@@ -18,6 +18,6 @@ private class HasBeenLastCalledWith {
     myBakery.order(new Pastry('Croissant'));
 
     // Assert
-    Assertions.assertThat(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Croissant'));
+    mockery.Assertions.assertThat(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Croissant'));
   }
 }

--- a/force-app/recipes/classes/asserting/HasNotBeenCalled.cls
+++ b/force-app/recipes/classes/asserting/HasNotBeenCalled.cls
@@ -9,12 +9,12 @@ private class HasNotBeenCalled {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
 
     // Act
 
     // Assert
-    Assertions.assertThat(planDeliverySpy).hasNotBeenCalled();
+    mockery.Assertions.assertThat(planDeliverySpy).hasNotBeenCalled();
   }
 }

--- a/force-app/recipes/classes/asserting/HasNotBeenCalled.cls
+++ b/force-app/recipes/classes/asserting/HasNotBeenCalled.cls
@@ -9,7 +9,7 @@ private class HasNotBeenCalled {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
 
     // Act

--- a/force-app/recipes/classes/mocking/NoConfiguration.cls
+++ b/force-app/recipes/classes/mocking/NoConfiguration.cls
@@ -9,8 +9,8 @@ private class NoConfiguration {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 
     // Act

--- a/force-app/recipes/classes/mocking/NoConfiguration.cls
+++ b/force-app/recipes/classes/mocking/NoConfiguration.cls
@@ -9,7 +9,7 @@ private class NoConfiguration {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
 

--- a/force-app/recipes/classes/mocking/Returns.cls
+++ b/force-app/recipes/classes/mocking/Returns.cls
@@ -9,8 +9,8 @@ private class Returns {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.returns(Date.today().addDays(3));
 

--- a/force-app/recipes/classes/mocking/Returns.cls
+++ b/force-app/recipes/classes/mocking/Returns.cls
@@ -9,7 +9,7 @@ private class Returns {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.returns(Date.today().addDays(3));

--- a/force-app/recipes/classes/mocking/ReturnsThenThrows.cls
+++ b/force-app/recipes/classes/mocking/ReturnsThenThrows.cls
@@ -9,7 +9,7 @@ private class ReturnsThenThrows {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.returns(Date.today().addDays(3));

--- a/force-app/recipes/classes/mocking/ReturnsThenThrows.cls
+++ b/force-app/recipes/classes/mocking/ReturnsThenThrows.cls
@@ -9,8 +9,8 @@ private class ReturnsThenThrows {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.returns(Date.today().addDays(3));
     planDeliverySpy.throwsException(new RecipeException());

--- a/force-app/recipes/classes/mocking/Throws.cls
+++ b/force-app/recipes/classes/mocking/Throws.cls
@@ -9,7 +9,7 @@ private class Throws {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.throwsException(new RecipeException());

--- a/force-app/recipes/classes/mocking/Throws.cls
+++ b/force-app/recipes/classes/mocking/Throws.cls
@@ -9,8 +9,8 @@ private class Throws {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.throwsException(new RecipeException());
 

--- a/force-app/recipes/classes/mocking/ThrowsThenReturns.cls
+++ b/force-app/recipes/classes/mocking/ThrowsThenReturns.cls
@@ -9,8 +9,8 @@ private class ThrowsThenReturns {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.throwsException(new RecipeException());
     planDeliverySpy.returns(Date.today().addDays(3));

--- a/force-app/recipes/classes/mocking/ThrowsThenReturns.cls
+++ b/force-app/recipes/classes/mocking/ThrowsThenReturns.cls
@@ -9,7 +9,7 @@ private class ThrowsThenReturns {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.throwsException(new RecipeException());

--- a/force-app/recipes/classes/mocking/WhenCalledWithCustomMatcher_ThenReturns.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithCustomMatcher_ThenReturns.cls
@@ -9,7 +9,7 @@ private class WhenCalledWithCustomMatcher_ThenReturns {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new OperaPastryMatcher()).thenReturn(Date.today().addDays(3));

--- a/force-app/recipes/classes/mocking/WhenCalledWithCustomMatcher_ThenReturns.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithCustomMatcher_ThenReturns.cls
@@ -9,8 +9,8 @@ private class WhenCalledWithCustomMatcher_ThenReturns {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new OperaPastryMatcher()).thenReturn(Date.today().addDays(3));
 

--- a/force-app/recipes/classes/mocking/WhenCalledWithEqualMatching_ThenReturn.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithEqualMatching_ThenReturn.cls
@@ -9,12 +9,12 @@ private class WhenCalledWithEqualMatching_ThenReturn {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));
     planDeliverySpy.whenCalledWith(new Pastry('Opera')).thenReturn(Date.today().addDays(2));
-    planDeliverySpy.whenCalledWith(Matcher.ofType(Pastry.class)).thenReturn(Date.today().addDays(4)); // Order matter
+    planDeliverySpy.whenCalledWith(mockery.Matcher.ofType(Pastry.class)).thenReturn(Date.today().addDays(4)); // Order matter
 
     // Act
     OrderConfirmation order = myBakery.order(new Pastry('Opera'));

--- a/force-app/recipes/classes/mocking/WhenCalledWithEqualMatching_ThenReturn.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithEqualMatching_ThenReturn.cls
@@ -9,7 +9,7 @@ private class WhenCalledWithEqualMatching_ThenReturn {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));

--- a/force-app/recipes/classes/mocking/WhenCalledWithJSONMatching_ThenReturn.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithJSONMatching_ThenReturn.cls
@@ -9,7 +9,7 @@ private class WhenCalledWithJSONMatching_ThenReturn {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(mockery.Matcher.jsonEquals(new Pastry('Opera'))).thenReturn(Date.today().addDays(4)); // Order matter

--- a/force-app/recipes/classes/mocking/WhenCalledWithJSONMatching_ThenReturn.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithJSONMatching_ThenReturn.cls
@@ -9,10 +9,10 @@ private class WhenCalledWithJSONMatching_ThenReturn {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
-    planDeliverySpy.whenCalledWith(Matcher.jsonEquals(new Pastry('Opera'))).thenReturn(Date.today().addDays(4)); // Order matter
+    planDeliverySpy.whenCalledWith(mockery.Matcher.jsonEquals(new Pastry('Opera'))).thenReturn(Date.today().addDays(4)); // Order matter
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));
     planDeliverySpy.whenCalledWith(new Pastry('Opera')).thenReturn(Date.today().addDays(2));
 

--- a/force-app/recipes/classes/mocking/WhenCalledWithMatchingThrowsAndReturns.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithMatchingThrowsAndReturns.cls
@@ -9,8 +9,8 @@ private class WhenCalledWithMatchingThrowsAndReturns {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.returns(Date.today().addDays(2));
     planDeliverySpy.throwsException(new RecipeException());

--- a/force-app/recipes/classes/mocking/WhenCalledWithMatchingThrowsAndReturns.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithMatchingThrowsAndReturns.cls
@@ -9,7 +9,7 @@ private class WhenCalledWithMatchingThrowsAndReturns {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.returns(Date.today().addDays(2));

--- a/force-app/recipes/classes/mocking/WhenCalledWithNotMatchingAndReturn.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithNotMatchingAndReturn.cls
@@ -9,8 +9,8 @@ private class WhenCalledWithNotMatchingAndReturn {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.returns(Date.today().addDays(4));
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));

--- a/force-app/recipes/classes/mocking/WhenCalledWithNotMatchingAndReturn.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithNotMatchingAndReturn.cls
@@ -9,7 +9,7 @@ private class WhenCalledWithNotMatchingAndReturn {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.returns(Date.today().addDays(4));

--- a/force-app/recipes/classes/mocking/WhenCalledWithTypeMatching_ThenReturn.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithTypeMatching_ThenReturn.cls
@@ -9,10 +9,10 @@ private class WhenCalledWithTypeMatching_ThenReturn {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
-    planDeliverySpy.whenCalledWith(Matcher.ofType(Pastry.class)).thenReturn(Date.today().addDays(4)); // Order matter
+    planDeliverySpy.whenCalledWith(mockery.Matcher.ofType(Pastry.class)).thenReturn(Date.today().addDays(4)); // Order matter
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));
     planDeliverySpy.whenCalledWith(new Pastry('Opera')).thenReturn(Date.today().addDays(2));
 

--- a/force-app/recipes/classes/mocking/WhenCalledWithTypeMatching_ThenReturn.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithTypeMatching_ThenReturn.cls
@@ -9,7 +9,7 @@ private class WhenCalledWithTypeMatching_ThenReturn {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(mockery.Matcher.ofType(Pastry.class)).thenReturn(Date.today().addDays(4)); // Order matter

--- a/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrow.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrow.cls
@@ -9,7 +9,7 @@ private class WhenCalledWith_ThenThrow {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));

--- a/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrow.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrow.cls
@@ -9,11 +9,11 @@ private class WhenCalledWith_ThenThrow {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));
-    planDeliverySpy.whenCalledWith(new Pastry('Opera')).thenThrow(new RecipeException());
+    planDeliverySpy.whenCalledWith(mockery.Params.of(new Pastry('Opera'))).thenThrow(new RecipeException());
 
     // Act
     try {

--- a/force-app/recipes/classes/mocking/WhenCalledWithoutMatchingConfiguration.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithoutMatchingConfiguration.cls
@@ -9,8 +9,8 @@ private class WhenCalledWithoutMatchingConfiguration {
   @isTest
   static void recipe() {
     // Arrange
-    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
-    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));
     planDeliverySpy.whenCalledWith(new Pastry('Chocolatine')).thenReturn(Date.today().addDays(2));
@@ -22,7 +22,7 @@ private class WhenCalledWithoutMatchingConfiguration {
       // Assert
       Assert.fail('Expected exception was not thrown');
     } catch (Exception ex) {
-      Assert.isInstanceOfType(ex, MethodSpy.ConfigurationException.class);
+      Assert.isInstanceOfType(ex, mockery.MethodSpy.ConfigurationException.class);
     }
   }
 }

--- a/force-app/recipes/classes/mocking/WhenCalledWithoutMatchingConfiguration.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWithoutMatchingConfiguration.cls
@@ -9,7 +9,7 @@ private class WhenCalledWithoutMatchingConfiguration {
   @isTest
   static void recipe() {
     // Arrange
-    mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class);
+    mockery.Mock deliveryServiceMock = MockFactory.forType(DeliveryService.class);
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
     planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturn(Date.today().addDays(3));

--- a/force-app/recipes/classes/utils/MockFactory.cls
+++ b/force-app/recipes/classes/utils/MockFactory.cls
@@ -1,0 +1,8 @@
+@isTest
+public class MockFactory {
+  public static mockery.Mock forType(final Type aType) {
+    final mockery.Mock mockInstance = new mockery.Mock();
+    mockInstance.stub = Test.createStub(aType, mockInstance);
+    return mockInstance;
+  }
+}

--- a/force-app/recipes/classes/utils/MockFactory.cls-meta.xml
+++ b/force-app/recipes/classes/utils/MockFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/src/classes/Assertions.cls
+++ b/force-app/src/classes/Assertions.cls
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 @IsTest
-public class Assertions {
-  public interface MethodSpyAssertions {
+global class Assertions {
+  global interface MethodSpyAssertions {
     /**
      * Assert that a method spy has never been called
      */
@@ -51,11 +51,11 @@ public class Assertions {
     void hasBeenLastCalledWith(final Object param1, final Object param2, final Object param3, final Object param4, final Object param5);
   }
 
-  public interface ErrorMessage {
+  global interface ErrorMessage {
     String toString();
   }
 
-  public interface Asserter {
+  global interface Asserter {
     void isTrue(Boolean value, ErrorMessage message);
     void isFalse(Boolean value, ErrorMessage message);
   }
@@ -66,7 +66,7 @@ public class Assertions {
    * @param spy the MethodSpy to assert
    * @see       MethodSpy
    */
-  public static MethodSpyAssertions assertThat(MethodSpy spy) {
+  global static MethodSpyAssertions assertThat(MethodSpy spy) {
     return assertThat(spy, METHOD_SPY_ASSERTER);
   }
 
@@ -262,7 +262,7 @@ public class Assertions {
       return rows;
     }
 
-    override public String toString() {
+    override global String toString() {
       final String headline = this.buildHeadline(spy, error, argument);
       final List<ErrorMessageRow> callTraces = this.buildCallTraces(spy);
 

--- a/force-app/src/classes/Assertions.cls
+++ b/force-app/src/classes/Assertions.cls
@@ -262,7 +262,7 @@ global class Assertions {
       return rows;
     }
 
-    override global String toString() {
+    override public String toString() {
       final String headline = this.buildHeadline(spy, error, argument);
       final List<ErrorMessageRow> callTraces = this.buildCallTraces(spy);
 

--- a/force-app/src/classes/Matcher.cls
+++ b/force-app/src/classes/Matcher.cls
@@ -15,38 +15,38 @@
  *    - Matcher.ofType(Schema.SObjectType sobjectType)
  */
 @IsTest
-public class Matcher {
-  public interface ArgumentMatcher {
+global class Matcher {
+  global interface ArgumentMatcher {
     Boolean matches(Object callArgument);
   }
 
-  public class MatcherException extends Exception {
+  global class MatcherException extends Exception {
   }
 
   private Matcher() {
   }
 
-  public static ArgumentMatcher any() {
+  global static ArgumentMatcher any() {
     return new AnyMatcher();
   }
 
-  public static ArgumentMatcher equals(final Object callArgument) {
+  global static ArgumentMatcher equals(final Object callArgument) {
     return new EqualsMatcher(callArgument);
   }
 
-  public static ArgumentMatcher jsonEquals(final Object callArgument) {
+  global static ArgumentMatcher jsonEquals(final Object callArgument) {
     return new JSONMatcher(callArgument);
   }
 
-  public static ArgumentMatcher ofType(final String matchingType) {
+  global static ArgumentMatcher ofType(final String matchingType) {
     return new TypeMatcher(matchingType);
   }
 
-  public static ArgumentMatcher ofType(final Schema.SObjectType callArgument) {
+  global static ArgumentMatcher ofType(final Schema.SObjectType callArgument) {
     return new TypeMatcher(callArgument);
   }
 
-  public static ArgumentMatcher ofType(final Type callArgument) {
+  global static ArgumentMatcher ofType(final Type callArgument) {
     return new TypeMatcher(callArgument);
   }
 

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -15,21 +15,21 @@
  *  @see Matcher
  */
 @IsTest
-public class MethodSpy {
-  public String methodName { get; private set; }
-  public CallLog callLog { get; private set; }
+global class MethodSpy {
+  global String methodName { get; private set; }
+  global CallLog callLog { get; private set; }
   private List<ParameterizedMethodSpyCall> parameterizedMethodCalls = new List<ParameterizedMethodSpyCall>();
   private Object returnValue;
   private Boolean configuredGlobalReturn = false;
   private Boolean configuredGlobalThrow = false;
   private Exception exceptionToThrow;
 
-  public MethodSpy(String methodName) {
+  global MethodSpy(String methodName) {
     this.methodName = methodName;
     this.callLog = new CallLog();
   }
 
-  public Object call(List<Object> params) {
+  global Object call(List<Object> params) {
     this.callLog.add(new MethodCall(params));
 
     if (this.parameterizedMethodCalls.isEmpty() && !this.configuredGlobalReturn && !this.configuredGlobalThrow) {
@@ -56,39 +56,39 @@ public class MethodSpy {
     throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallParams(params).build();
   }
 
-  public void returns(Object value) {
+  global void returns(Object value) {
     this.configuredGlobalReturn = true;
     this.configuredGlobalThrow = false;
     this.returnValue = value;
   }
 
-  public void throwsException(Exception exceptionToThrow) {
+  global void throwsException(Exception exceptionToThrow) {
     this.configuredGlobalThrow = true;
     this.configuredGlobalReturn = false;
     this.exceptionToThrow = exceptionToThrow;
   }
 
-  public MethodSpyCall whenCalledWith() {
+  global MethodSpyCall whenCalledWith() {
     return this.whenCalledWithParams(Params.empty());
   }
 
-  public MethodSpyCall whenCalledWith(final Object arg) {
+  global MethodSpyCall whenCalledWith(final Object arg) {
     return this.whenCalledWithParams((arg == null || arg instanceof Params) ? (Params) arg : Params.of(arg));
   }
 
-  public MethodSpyCall whenCalledWith(final Object arg1, final Object arg2) {
+  global MethodSpyCall whenCalledWith(final Object arg1, final Object arg2) {
     return this.whenCalledWithParams(Params.of(arg1, arg2));
   }
 
-  public MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3) {
+  global MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3) {
     return this.whenCalledWithParams(Params.of(arg1, arg2, arg3));
   }
 
-  public MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+  global MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
     return this.whenCalledWithParams(Params.of(arg1, arg2, arg3, arg4));
   }
 
-  public MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+  global MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
     return this.whenCalledWithParams(Params.of(arg1, arg2, arg3, arg4, arg5));
   }
 
@@ -101,26 +101,26 @@ public class MethodSpy {
     return parameterizedMethodCall;
   }
 
-  public class CallLog {
+  global class CallLog {
     private List<MethodCall> callParams = new List<MethodCall>();
 
     private void add(MethodCall callParam) {
       this.callParams.add(callParam);
     }
 
-    public Boolean isEmpty() {
+    global Boolean isEmpty() {
       return this.callParams.isEmpty();
     }
 
-    public Integer size() {
+    global Integer size() {
       return this.callParams.size();
     }
 
-    public List<Object> get(final Integer index) {
+    global List<Object> get(final Integer index) {
       return this.callParams[index].params;
     }
 
-    public List<Object> getLast() {
+    global List<Object> getLast() {
       return this.size() > 0 ? this.get(this.size() - 1) : null;
     }
   }
@@ -133,7 +133,7 @@ public class MethodSpy {
     }
   }
 
-  public interface MethodSpyCall {
+  global interface MethodSpyCall {
     void thenReturn(Object value);
     void thenThrow(Exception error);
   }
@@ -197,6 +197,6 @@ public class MethodSpy {
     }
   }
 
-  public class ConfigurationException extends Exception {
+  global class ConfigurationException extends Exception {
   }
 }

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -29,7 +29,7 @@ global class MethodSpy {
     this.callLog = new CallLog();
   }
 
-  global Object call(List<Object> params) {
+  public Object call(List<Object> params) {
     this.callLog.add(new MethodCall(params));
 
     if (this.parameterizedMethodCalls.isEmpty() && !this.configuredGlobalReturn && !this.configuredGlobalThrow) {
@@ -101,26 +101,26 @@ global class MethodSpy {
     return parameterizedMethodCall;
   }
 
-  global class CallLog {
+  public class CallLog {
     private List<MethodCall> callParams = new List<MethodCall>();
 
     private void add(MethodCall callParam) {
       this.callParams.add(callParam);
     }
 
-    global Boolean isEmpty() {
+    public Boolean isEmpty() {
       return this.callParams.isEmpty();
     }
 
-    global Integer size() {
+    public Integer size() {
       return this.callParams.size();
     }
 
-    global List<Object> get(final Integer index) {
+    public List<Object> get(final Integer index) {
       return this.callParams[index].params;
     }
 
-    global List<Object> getLast() {
+    public List<Object> getLast() {
       return this.size() > 0 ? this.get(this.size() - 1) : null;
     }
   }

--- a/force-app/src/classes/Mock.cls
+++ b/force-app/src/classes/Mock.cls
@@ -6,11 +6,14 @@
  */
 @isTest
 global class Mock implements System.StubProvider {
-  global Object stub { get; private set; }
+  global Object stub { get; set; }
   private Map<String, MethodSpy> spies = new Map<String, MethodSpy>();
 
   private Mock(final Type aType) {
     this.stub = Test.createStub(aType, this);
+  }
+
+  global Mock() {
   }
 
   global Object handleMethodCall(

--- a/force-app/src/classes/Mock.cls
+++ b/force-app/src/classes/Mock.cls
@@ -13,6 +13,7 @@ global class Mock implements System.StubProvider {
     this.stub = Test.createStub(aType, this);
   }
 
+  @SuppressWarnings('PMD.EmptyStatementBlock')
   global Mock() {
   }
 

--- a/force-app/src/classes/Mock.cls
+++ b/force-app/src/classes/Mock.cls
@@ -5,15 +5,15 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 @isTest
-public class Mock implements System.StubProvider {
-  public Object stub { get; private set; }
+global class Mock implements System.StubProvider {
+  global Object stub { get; private set; }
   private Map<String, MethodSpy> spies = new Map<String, MethodSpy>();
 
   private Mock(final Type aType) {
     this.stub = Test.createStub(aType, this);
   }
 
-  public Object handleMethodCall(
+  global Object handleMethodCall(
     Object stubbedObject,
     String stubbedMethodName,
     Type returnType,
@@ -30,18 +30,18 @@ public class Mock implements System.StubProvider {
     return result;
   }
 
-  public MethodSpy spyOn(final String methodName) {
+  global MethodSpy spyOn(final String methodName) {
     if (!this.spies.containsKey(methodName)) {
       this.spies.put(methodName, new MethodSpy(methodName));
     }
     return this.getSpy(methodName);
   }
 
-  public MethodSpy getSpy(final String methodName) {
+  global MethodSpy getSpy(final String methodName) {
     return this.spies.get(methodName);
   }
 
-  public static Mock forType(final Type aType) {
+  global static Mock forType(final Type aType) {
     return new Mock(aType);
   }
 }

--- a/force-app/src/classes/Params.cls
+++ b/force-app/src/classes/Params.cls
@@ -23,7 +23,7 @@ global class Params {
     }
   }
 
-  global boolean matches(final List<Object> callArguments) {
+  public boolean matches(final List<Object> callArguments) {
     if (this.listOfArgs.size() != callArguments?.size()) {
       return false;
     }

--- a/force-app/src/classes/Params.cls
+++ b/force-app/src/classes/Params.cls
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 @IsTest
-public class Params {
+global class Params {
   private List<Matcher.ArgumentMatcher> listOfArgs;
 
   private Params() {
@@ -23,7 +23,7 @@ public class Params {
     }
   }
 
-  public boolean matches(final List<Object> callArguments) {
+  global boolean matches(final List<Object> callArguments) {
     if (this.listOfArgs.size() != callArguments?.size()) {
       return false;
     }
@@ -37,35 +37,35 @@ public class Params {
     return true;
   }
 
-  public override String toString() {
+  global override String toString() {
     return this.listOfArgs + '';
   }
 
-  public static Params empty() {
+  global static Params empty() {
     return new Params();
   }
 
-  public static Params of(final Object arg) {
+  global static Params of(final Object arg) {
     return new Params(new List<Object>{ arg });
   }
 
-  public static Params of(final Object arg1, final Object arg2) {
+  global static Params of(final Object arg1, final Object arg2) {
     return new Params(new List<Object>{ arg1, arg2 });
   }
 
-  public static Params of(final Object arg1, final Object arg2, final Object arg3) {
+  global static Params of(final Object arg1, final Object arg2, final Object arg3) {
     return new Params(new List<Object>{ arg1, arg2, arg3 });
   }
 
-  public static Params of(final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+  global static Params of(final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
     return new Params(new List<Object>{ arg1, arg2, arg3, arg4 });
   }
 
-  public static Params of(final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+  global static Params of(final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
     return new Params(new List<Object>{ arg1, arg2, arg3, arg4, arg5 });
   }
 
-  public static Params ofList(final List<Object> listOfArgs) {
+  global static Params ofList(final List<Object> listOfArgs) {
     if (listOfArgs == null) {
       return Params.empty();
     }

--- a/force-app/test/classes/unit/MockTest.cls
+++ b/force-app/test/classes/unit/MockTest.cls
@@ -8,6 +8,24 @@
 private class MockTest {
   // Integration test
   @IsTest
+  static void givenAType_whenBuildingOutsideNamespace_andSpyinOnWithReturn_callingTheMethodReturnsTheConfiguredOutput() {
+    // Arrange
+    String expected = 'expected';
+    Mock mock = new Mock();
+    mock.stub = Test.createStub(DummyInterface.class, mock);
+    MethodSpy dummyMethod = mock.spyOn('dummyMethod');
+    dummyMethod.returns(expected);
+    DummyInterface sut = (DummyInterface) mock.stub;
+
+    // Act
+    String result = sut.dummyMethod();
+
+    // Assert
+    Assert.areEqual(expected, result);
+  }
+
+  // Integration test
+  @IsTest
   static void givenAType_whenSpyinOnWithReturn_callingTheMethodReturnsTheConfiguredOutput() {
     // Arrange
     String expected = 'expected';

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -18,6 +18,6 @@
   "sfdcLoginUrl": "https://login.salesforce.com",
   "sourceApiVersion": "56.0",
   "packageAliases": {
-    "Apex Mockery": "0HoDn000000k9rOKAQ"
+    "Apex Mockery": "0HoDn000000kA5kKAE"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -11,10 +11,6 @@
     {
       "path": "force-app/test",
       "default": false
-    },
-    {
-      "path": "force-app/recipes",
-      "default": false
     }
   ],
   "name": "apex-mockery",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The solution here is to go for an unlocked package with namespace and to provide mechanism to overcome the [same namespace stub creation limitation](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_testing_stub_api.htm#:~:text=The%20object%20being%20mocked%20must%20be%20in%20the%20same%20namespace%20as%20the%20call%20to%20the%20Test.createStub()%20method.%20However%2C%20the%20implementation%20of%20the%20StubProvider%20interface%20can%20be%20in%20another%20namespace.)
This PR provide a `MockFactory` outside the package, used to stub type in the same namespace

All the classes have the global modifiers where necessary
Thanks to @jongpie and @chazwatkins for the discovery of this issue and the global modifier

The package is a new one with the `mockery` namespace

Related [ADR](https://github.com/salesforce/apex-mockery/wiki/Unlocked-Package-namespace-strategy)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closes #36 

Based on #35 works 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Inside this PR with a new validation step