### PR TITLE
ci: use multiline syntax for links env variable

### DIFF
--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -59,7 +59,7 @@ jobs:
 
   update-release:
     runs-on: ubuntu-latest
-    needs: create-package-version
+    needs: [create-package-version, promote-package-version]
     steps:
       - name: Create package links
         run: |
@@ -71,7 +71,9 @@ jobs:
           - sfdx command: \`sfdx force:package:install --package $packageId\`
           EOF
           )
-          echo "links=$links" >> $GITHUB_ENV
+          echo "links<<EOF" >> $GITHUB_ENV
+          echo "$links" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Update release with package Id
         uses: irongut/EditRelease@v1.2.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

fix `.github/workflows/on-release-published.yml` `update-release` job.
It was using a monoline variable definition where it was multiline

Make sure the `update-release` job is done after promoting the release

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make sure release update and communication is automatically done when releasing

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Using CI/CD
