### PR TITLE
feat: add names and types of method parameters in error output

### DIFF
--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -169,7 +169,7 @@ global class Argument {
     }
 
     public boolean matches(final Object callArgument) {
-      String typeName = this.getTypeName(callArgument);
+      String typeName = Argument.getTypeName(callArgument);
       if (this.callArgumentToMatch == typeName) {
         return true;
       }
@@ -182,19 +182,24 @@ global class Argument {
       return false;
     }
 
-    private String getTypeName(final Object callArgument) {
-      String result = 'Date';
-      try {
-        Date typeCheck = (Date) callArgument;
-      } catch (System.TypeException te) {
-        String message = te.getMessage().substringAfter('Invalid conversion from runtime type ');
-        result = message.substringBefore(' to Date');
-      }
-      return result;
-    }
-
     override public String toString() {
       return callArgumentToMatch + '.Type';
     }
+  }
+
+  private static String getTypeName(final Object callArgument) {
+    String result = 'Date';
+    try {
+      Date typeCheck = (Date) callArgument;
+    } catch (System.TypeException te) {
+      String message = te.getMessage().substringAfter('Invalid conversion from runtime type ');
+      result = message.substringBefore(' to Date');
+    }
+    return result;
+  }
+
+  public static Type getType(final Object callArgument) {
+    final String typeName = getTypeName(callArgument);
+    return Type.forName(typeName);
   }
 }

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -136,20 +136,18 @@ global class Argument {
   }
 
   private class JSONMatchable implements Argument.Matchable {
-    private Object callArgumentToMatch;
     private String jsonValue;
 
     public JSONMatchable(final Object callArgumentToMatch) {
-      this.callArgumentToMatch = callArgumentToMatch;
       this.jsonValue = JSON.serialize(callArgumentToMatch);
     }
 
     public boolean matches(final Object callArgument) {
-      return this.jsonValue == JSON.serialize(callArgument);
+      return String.valueOf(this.jsonValue).equals(String.valueOf(JSON.serialize(callArgument)));
     }
 
     override public String toString() {
-      return 'json(' + this.callArgumentToMatch + ')';
+      return 'json(' + this.jsonValue + ')';
     }
   }
 

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -131,7 +131,7 @@ global class Argument {
     }
 
     override public String toString() {
-      return callArgumentToMatch + '';
+      return this.callArgumentToMatch + '';
     }
   }
 
@@ -149,7 +149,7 @@ global class Argument {
     }
 
     override public String toString() {
-      return 'json(' + callArgumentToMatch + ')';
+      return 'json(' + this.callArgumentToMatch + ')';
     }
   }
 
@@ -183,7 +183,7 @@ global class Argument {
     }
 
     override public String toString() {
-      return callArgumentToMatch + '.Type';
+      return this.callArgumentToMatch + '.Type';
     }
   }
 

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -169,7 +169,7 @@ global class Argument {
     }
 
     public boolean matches(final Object callArgument) {
-      String typeName = this.getType(callArgument);
+      String typeName = this.getTypeName(callArgument);
       if (this.callArgumentToMatch == typeName) {
         return true;
       }
@@ -182,7 +182,7 @@ global class Argument {
       return false;
     }
 
-    private String getType(final Object callArgument) {
+    private String getTypeName(final Object callArgument) {
       String result = 'Date';
       try {
         Date typeCheck = (Date) callArgument;

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -29,7 +29,7 @@ global class MethodSpy {
     this.callLog = new CallLog();
   }
 
-  public Object call(List<Object> args) {
+  public Object call(List<Type> paramTypes, List<String> paramNames, List<Object> args) {
     this.callLog.add(new MethodCall(args));
 
     if (this.parameterizedMethodCalls.isEmpty() && !this.configuredGlobalReturn && !this.configuredGlobalThrow) {
@@ -53,7 +53,7 @@ global class MethodSpy {
       throw this.exceptionToThrow;
     }
 
-    throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallArguments(args).build();
+    throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallTypes(paramTypes).withCallParamNames(paramNames).withCallArguments(args).build();
   }
 
   global void returns(Object value) {
@@ -167,10 +167,22 @@ global class MethodSpy {
 
   private class ConfigurationExceptionBuilder {
     private MethodSpy spy;
+    private List<Type> callTypes;
+    private List<String> callParamNames;
     private List<Object> callArguments;
 
     public ConfigurationExceptionBuilder withMethodSpy(final MethodSpy spy) {
       this.spy = spy;
+      return this;
+    }
+
+    public ConfigurationExceptionBuilder withCallTypes(final List<Type> callTypes) {
+      this.callTypes = callTypes;
+      return this;
+    }
+
+    public ConfigurationExceptionBuilder withCallParamNames(final List<String> callParamNames) {
+      this.callParamNames = callParamNames;
       return this;
     }
 
@@ -184,10 +196,17 @@ global class MethodSpy {
       for (ParameterizedMethodSpyCall parameterizedCall : this.spy.parameterizedMethodCalls) {
         errorMessages.add(parameterizedCall.toString());
       }
+
+      List<String> callArgumentsAsString = new List<String>();
+      for (Integer i = 0; i < this.callArguments.size(); i++) {
+        callArgumentsAsString.add(this.callTypes[i] + ' ' + this.callParamNames[i] + '[' + this.callArguments[i] + ']');
+      }
       return new ConfigurationException(
-        this.spy.methodName +
-          ': No stub value found for a call with args ' +
-          this.callArguments +
+        'No stub value found for a call of ' +
+          this.spy.methodName +
+          '(' +
+          String.join(callArgumentsAsString, ', ') +
+          ')' +
           '\nHere are the configured stubs:\n\t' +
           String.join(errorMessages, '\n\t')
       );

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -29,6 +29,27 @@ global class MethodSpy {
     this.callLog = new CallLog();
   }
 
+  // @deprecated use call(List<Type> paramTypes, List<String> paramNames, List<Object> args) instead
+  public Object call(List<Object> args) {
+    // Forward compatibility implementation
+    List<Type> paramTypes = new List<Type>();
+    List<String> paramNames = new List<String>();
+
+    for (Object arg : args) {
+      paramTypes.add(Argument.getType(arg)); // Infer type dynamically
+      paramNames.add('<unknown_param_name>'); // Impossible to get this information at runtime
+    }
+
+    // Warn consumer
+    System.Debug(
+      LoggingLevel.WARN,
+      '[apex-mockery] call to the deprecated MethodSpy.call(List<Object> args) method.\nPlease use MethodSpy.call(List<Type> paramTypes, List<String> paramNames, List<Object> args) instead.'
+    );
+
+    // Interoperability
+    return this.call(paramTypes, paramNames, args);
+  }
+
   public Object call(List<Type> paramTypes, List<String> paramNames, List<Object> args) {
     this.callLog.add(new MethodCall(args));
 

--- a/force-app/src/classes/Mock.cls
+++ b/force-app/src/classes/Mock.cls
@@ -24,7 +24,7 @@ global class Mock implements System.StubProvider {
     Object result;
     if (this.spies.containsKey(stubbedMethodName)) {
       MethodSpy spy = this.getSpy(stubbedMethodName);
-      result = spy.call(listOfArgs);
+      result = spy.call(listOfParamTypes, listOfParamNames, listOfArgs);
     }
 
     return result;

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -565,4 +565,36 @@ public class ArgumentTest {
       return true;
     }
   }
+
+  @IsTest
+  static void getType_whenCalledWithSObject_returnsSObjectType() {
+    // Assert
+    Assert.areEqual(Account.class, Argument.getType(new Account()));
+    Assert.areEqual(Opportunity.class, Argument.getType(new Opportunity()));
+  }
+
+  @IsTest
+  static void getType_whenCalledWithPrimitive_returnsPrimitiveType() {
+    // Assert
+    Assert.areEqual(Blob.class, Argument.getType(Blob.valueOf('test')));
+    Assert.areEqual(Boolean.class, Argument.getType(true));
+    Assert.areEqual(Date.class, Argument.getType(Date.today()));
+    Assert.areEqual(Datetime.class, Argument.getType(Datetime.now()));
+    Decimal dec = 42.0;
+    Assert.areEqual(Decimal.class, Argument.getType(dec));
+    Assert.areEqual(Double.class, Argument.getType(42.0d));
+    Id contactId = '00300000003T2PGAA0';
+    Assert.areEqual(ID.class, Argument.getType(contactId));
+    Assert.areEqual(Integer.class, Argument.getType(42));
+    Assert.areEqual(Long.class, Argument.getType(42L));
+    Assert.areEqual(String.class, Argument.getType('test'));
+    Assert.areEqual(Time.class, Argument.getType(Time.newInstance(10, 10, 10, 10)));
+  }
+
+  @IsTest
+  static void getType_whenCalledWithObject_returnObjectType() {
+    // Assert
+    Assert.areEqual(List<Account>.class, Argument.getType(new List<Account>()));
+    Assert.areEqual(ArgumentTest.class, Argument.getType(new ArgumentTest()));
+  }
 }

--- a/force-app/test/package/classes/unit/ExpectTest.cls
+++ b/force-app/test/package/classes/unit/ExpectTest.cls
@@ -140,7 +140,7 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ 'param' });
+    spy.call(new List<Type>{ String.class }, new List<String>{ 'name' }, new List<Object>{ 'param' });
 
     // Act
     sut.hasBeenCalledWith(Argument.of('param'));
@@ -157,7 +157,7 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ '2', 'param' });
+    spy.call(new List<Type>{ Integer.class, String.class }, new List<String>{ 'count', 'name' }, new List<Object>{ '2', 'param' });
 
     // Act
     sut.hasBeenCalledWith('2', 'param');
@@ -174,7 +174,11 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ '3', 'param', 'test' });
+    spy.call(
+      new List<Type>{ Integer.class, String.class, String.class },
+      new List<String>{ 'count', 'name', 'otherName' },
+      new List<Object>{ '3', 'param', 'test' }
+    );
 
     // Act
     sut.hasBeenCalledWith('3', 'param', 'test');
@@ -191,7 +195,11 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ '4', 'param', 'unit', 'test' });
+    spy.call(
+      new List<Type>{ Integer.class, String.class, String.class, String.class },
+      new List<String>{ 'count', 'name', 'otherName', 'yetAnotherName' },
+      new List<Object>{ '4', 'param', 'unit', 'test' }
+    );
 
     // Act
     sut.hasBeenCalledWith('4', 'param', 'unit', 'test');
@@ -208,7 +216,11 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ '5', 'param', 'unit', 'test', 'scenario' });
+    spy.call(
+      new List<Type>{ Integer.class, String.class, String.class, String.class, String.class },
+      new List<String>{ 'count', 'name', 'otherName', 'yetAnotherName', 'latestArgument' },
+      new List<Object>{ '5', 'param', 'unit', 'test', 'scenario' }
+    );
 
     // Act
     sut.hasBeenCalledWith('5', 'param', 'unit', 'test', 'scenario');
@@ -225,7 +237,7 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ 'param' });
+    spy.call(new List<Type>{ String.class }, new List<String>{ 'name' }, new List<Object>{ 'param' });
 
     // Act
     sut.hasBeenCalledWith(Argument.equals('param'));
@@ -241,7 +253,7 @@ private class ExpectTest {
     MethodSpy spy = new MethodSpy('method');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>());
+    spy.call(new List<Type>{}, new List<String>{}, new List<Object>{});
 
     // Act
     sut.hasBeenCalledWith(null);
@@ -322,7 +334,7 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ 'param' });
+    spy.call(new List<Type>{ String.class }, new List<String>{ 'name' }, new List<Object>{ 'param' });
 
     // Act
     sut.hasBeenLastCalledWith(Argument.of('param'));
@@ -339,7 +351,7 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ '2', 'param' });
+    spy.call(new List<Type>{ Integer.class, String.class }, new List<String>{ 'count', 'name' }, new List<Object>{ '2', 'param' });
 
     // Act
     sut.hasBeenLastCalledWith('2', 'param');
@@ -356,7 +368,11 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ '3', 'param', 'test' });
+    spy.call(
+      new List<Type>{ Integer.class, String.class, String.class },
+      new List<String>{ 'count', 'name', 'anotherName' },
+      new List<Object>{ '3', 'param', 'test' }
+    );
 
     // Act
     sut.hasBeenLastCalledWith('3', 'param', 'test');
@@ -373,7 +389,11 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ '4', 'param', 'unit', 'test' });
+    spy.call(
+      new List<Type>{ Integer.class, String.class, String.class, String.class },
+      new List<String>{ 'count', 'name', 'anotherName', 'yetAnotherName' },
+      new List<Object>{ '4', 'param', 'unit', 'test' }
+    );
 
     // Act
     sut.hasBeenLastCalledWith('4', 'param', 'unit', 'test');
@@ -390,7 +410,11 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ '5', 'param', 'unit', 'test', 'scenario' });
+    spy.call(
+      new List<Type>{ Integer.class, String.class, String.class, String.class, String.class },
+      new List<String>{ 'count', 'name', 'anotherName', 'yetAnotherName', 'lastParameter' },
+      new List<Object>{ '5', 'param', 'unit', 'test', 'scenario' }
+    );
 
     // Act
     sut.hasBeenLastCalledWith('5', 'param', 'unit', 'test', 'scenario');
@@ -407,7 +431,7 @@ private class ExpectTest {
     spy.returns('anything');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>{ 'param' });
+    spy.call(new List<Type>{ String.class }, new List<String>{ 'name' }, new List<Object>{ 'param' });
 
     // Act
     sut.hasBeenLastCalledWith(Argument.equals('param'));
@@ -423,7 +447,7 @@ private class ExpectTest {
     MethodSpy spy = new MethodSpy('method');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>());
+    spy.call(new List<Type>{}, new List<String>{}, new List<Object>());
 
     // Act
     sut.hasBeenLastCalledWith(null);
@@ -439,7 +463,7 @@ private class ExpectTest {
     MethodSpy spy = new MethodSpy('method');
     FakeAsserter fakeAsserter = new FakeAsserter();
     Expect.MethodSpyExpectable sut = Expect.that(spy, fakeAsserter);
-    spy.call(new List<Object>());
+    spy.call(new List<Type>{}, new List<String>{}, new List<Object>{});
 
     // Act & Assert
     sut.hasBeenCalledTimes(1);

--- a/force-app/test/package/classes/unit/MethodSpyTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyTest.cls
@@ -407,12 +407,12 @@ private class MethodSpyTest {
     sut.whenCalledWith('Expected First Param', true).thenReturn('Yet another expected Result');
     try {
       // Act
-      sut.call(new List<Object>{ 'Another Param', false });
+      sut.call(new List<Type>{ String.class, Boolean.class }, new List<String>{ 'param', 'bool' }, new List<Object>{ 'Another Param', false });
       Assert.fail('it shoud not reach this line');
     } catch (MethodSpy.ConfigurationException cex) {
       // Assert
       Assert.areEqual(
-        'methodName: No stub value found for a call with args (Another Param, false)\nHere are the configured stubs:\n\twhenCalledWith(Another Param, true).thenReturn(Expected Result)\n\twhenCalledWith(Expected First Param, false).thenReturn(Another expected Result)\n\twhenCalledWith(Expected First Param, true).thenReturn(Yet another expected Result)',
+        'No stub value found for a call of methodName(String param[Another Param], Boolean bool[false])\nHere are the configured stubs:\n\twhenCalledWith(Another Param, true).thenReturn(Expected Result)\n\twhenCalledWith(Expected First Param, false).thenReturn(Another expected Result)\n\twhenCalledWith(Expected First Param, true).thenReturn(Yet another expected Result)',
         cex.getMessage()
       );
     }

--- a/force-app/test/package/classes/unit/MethodSpyTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyTest.cls
@@ -14,7 +14,7 @@ private class MethodSpyTest {
     sut.whenCalledWith(null).thenReturn('test');
 
     // Act
-    Object result = sut.call(new List<Object>{ null });
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
 
     // Assert
     Assert.areEqual('test', result);
@@ -25,14 +25,14 @@ private class MethodSpyTest {
   static void givenSpyConfiguredWithArguments_whenCalledWithMatching_spyIsCalled() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
-    sut.whenCalledWith(Argument.of('param')).thenReturn('test');
+    sut.whenCalledWith(Argument.of('value')).thenReturn('test');
 
     // Act
-    Object result = sut.call(new List<Object>{ 'param' });
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'value' });
 
     // Assert
     Assert.areEqual('test', result);
-    Assert.areEqual(new List<Object>{ 'param' }, sut.callLog.getLast());
+    Assert.areEqual(new List<Object>{ 'value' }, sut.callLog.getLast());
   }
 
   @IsTest
@@ -42,7 +42,7 @@ private class MethodSpyTest {
     sut.whenCalledWith().thenReturn('test');
 
     // Act
-    Object result = sut.call(new List<Object>());
+    Object result = sut.call(new List<Type>(), new List<String>(), new List<Object>());
 
     // Assert
     Assert.areEqual('test', result);
@@ -56,7 +56,7 @@ private class MethodSpyTest {
     sut.whenCalledWith(Argument.empty()).thenReturn('test');
 
     // Act
-    Object result = sut.call(new List<Object>());
+    Object result = sut.call(new List<Type>(), new List<String>(), new List<Object>());
 
     // Assert
     Assert.areEqual('test', result);
@@ -70,7 +70,7 @@ private class MethodSpyTest {
     sut.whenCalledWith('2', 'args').thenReturn('test');
 
     // Act
-    Object result = sut.call(new List<Object>{ '2', 'args' });
+    Object result = sut.call(new List<Type>{ Integer.class, String.class }, new List<String>{ 'count', 'name' }, new List<Object>{ '2', 'args' });
 
     // Assert
     Assert.areEqual('test', result);
@@ -84,7 +84,11 @@ private class MethodSpyTest {
     sut.whenCalledWith('3', 'args', 'test').thenReturn('test');
 
     // Act
-    Object result = sut.call(new List<Object>{ '3', 'args', 'test' });
+    Object result = sut.call(
+      new List<Type>{ Integer.class, String.class, String.class },
+      new List<String>{ 'count', 'name', 'othername' },
+      new List<Object>{ '3', 'args', 'test' }
+    );
 
     // Assert
     Assert.areEqual('test', result);
@@ -98,7 +102,11 @@ private class MethodSpyTest {
     sut.whenCalledWith('test', 'with', '4', 'args').thenReturn('test');
 
     // Act
-    Object result = sut.call(new List<Object>{ 'test', 'with', '4', 'args' });
+    Object result = sut.call(
+      new List<Type>{ String.class, String.class, Integer.class, String.class },
+      new List<String>{ 'param', 'otherParam', 'count', 'yetanothername' },
+      new List<Object>{ 'test', 'with', '4', 'args' }
+    );
 
     // Assert
     Assert.areEqual('test', result);
@@ -112,7 +120,11 @@ private class MethodSpyTest {
     sut.whenCalledWith('another', 'test', 'with', '5', 'args').thenReturn('test');
 
     // Act
-    Object result = sut.call(new List<Object>{ 'another', 'test', 'with', '5', 'args' });
+    Object result = sut.call(
+      new List<Type>{ String.class, String.class, String.class, Integer.class, String.class },
+      new List<String>{ 'param', 'otherParam', 'anotherParam', 'count', 'yetanothername' },
+      new List<Object>{ 'another', 'test', 'with', '5', 'args' }
+    );
 
     // Assert
     Assert.areEqual('test', result);
@@ -126,7 +138,11 @@ private class MethodSpyTest {
     sut.whenCalledWith('param', new Account(Name = 'Test'), Argument.any()).thenReturn('Expected Result');
 
     // Act
-    Object result = sut.call(new List<Object>{ 'param', new Account(Name = 'Test'), true });
+    Object result = sut.call(
+      new List<Type>{ String.class, Account.class, Boolean.class },
+      new List<String>{ 'param', 'account', 'bool' },
+      new List<Object>{ 'param', new Account(Name = 'Test'), true }
+    );
 
     // Assert
     Assert.areEqual(new List<Object>{ 'param', new Account(Name = 'Test'), true }, sut.callLog.getLast());
@@ -141,7 +157,7 @@ private class MethodSpyTest {
 
     // Act
     try {
-      Object result = sut.call(new List<Object>{ 'param' });
+      Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'param' });
 
       // Assert
       Assert.fail('it shoud not reach this line');
@@ -163,7 +179,7 @@ private class MethodSpyTest {
 
     // Act
     try {
-      Object result = sut.call(new List<Object>{ new Opportunity() });
+      Object result = sut.call(new List<Type>{ Opportunity.class }, new List<String>{ 'oppy' }, new List<Object>{ new Opportunity() });
 
       // Assert
       Assert.fail('it shoud not reach this line');
@@ -182,7 +198,11 @@ private class MethodSpyTest {
       .thenReturn('Expected Result');
 
     // Act
-    Object result = sut.call(new List<Object>{ new List<String>{ 'test' }, new Account(Name = 'random'), true });
+    Object result = sut.call(
+      new List<Type>{ List<String>.class, Account.class, Boolean.class },
+      new List<String>{ 'params', 'account', 'bool' },
+      new List<Object>{ new List<String>{ 'test' }, new Account(Name = 'random'), true }
+    );
 
     // Assert
     Assert.areEqual('Expected Result', result);
@@ -196,11 +216,13 @@ private class MethodSpyTest {
     sut.whenCalledWith(new Account()).thenReturn('Account result');
     sut.whenCalledWith(new Opportunity()).thenReturn('Opportunity result');
 
-    // Act && Assert
-    Object firstCallResult = sut.call(new List<Object>{ new Account() });
+    // Act
+    Object firstCallResult = sut.call(new List<Type>{ Account.class }, new List<String>{ 'account' }, new List<Object>{ new Account() });
+
+    // Assert
     Assert.areEqual('Account result', firstCallResult);
     Assert.areEqual(new List<Object>{ new Account() }, sut.callLog.getLast());
-    Object secondCallResult = sut.call(new List<Object>{ new Opportunity() });
+    Object secondCallResult = sut.call(new List<Type>{ Opportunity.class }, new List<String>{ 'oppy' }, new List<Object>{ new Opportunity() });
     Assert.areEqual(new List<Object>{ new Account() }, sut.callLog.get(0));
     Assert.areEqual(new List<Object>{ new Opportunity() }, sut.callLog.getLast());
     Assert.areEqual('Opportunity result', secondCallResult);
@@ -211,10 +233,12 @@ private class MethodSpyTest {
     MethodSpy sut = new MethodSpy('methodName');
     sut.returns('String result');
 
-    // Act && Assert
-    Object result = sut.call(new List<Object>{ new Account() });
+    // Act
+    Object result = sut.call(new List<Type>{ Account.class }, new List<String>{ 'account' }, new List<Object>{ new Account() });
+
+    // Assert
     Assert.areEqual('String result', result);
-    result = sut.call(new List<Object>{ new Opportunity() });
+    result = sut.call(new List<Type>{ Opportunity.class }, new List<String>{ 'oppy' }, new List<Object>{ new Opportunity() });
     Assert.areEqual('String result', result);
   }
 
@@ -225,7 +249,7 @@ private class MethodSpyTest {
     sut.returns('String result');
 
     // Act
-    Object result = sut.call(new List<Object>{});
+    Object result = sut.call(new List<Type>{}, new List<String>{}, new List<Object>{});
 
     // Assert
     Assert.areEqual('String result', result);
@@ -240,7 +264,7 @@ private class MethodSpyTest {
     sut.returns('Last Configuration');
 
     // Act
-    Object result = sut.call(new List<Object>{});
+    Object result = sut.call(new List<Type>{}, new List<String>{}, new List<Object>{});
 
     // Assert
     Assert.areEqual('Last Configuration', result);
@@ -254,7 +278,7 @@ private class MethodSpyTest {
 
     try {
       // Act
-      sut.call(new List<Object>{});
+      sut.call(new List<Type>{}, new List<String>{}, new List<Object>{});
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       // Assert
@@ -275,7 +299,7 @@ private class MethodSpyTest {
 
     try {
       // Act
-      sut.call(new List<Object>{});
+      sut.call(new List<Type>{}, new List<String>{}, new List<Object>{});
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       // Assert
@@ -291,7 +315,7 @@ private class MethodSpyTest {
 
     try {
       // Act
-      sut.call(new List<Object>{ 'Expected Param' });
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'Expected Param' });
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       // Assert
@@ -306,7 +330,7 @@ private class MethodSpyTest {
     sut.whenCalledWith('Expected Param').thenReturn('Expected Result');
 
     // Act
-    Object result = sut.call(new List<Object>{ 'Expected Param' });
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'Expected Param' });
 
     // Assert
     Assert.areEqual('Expected Result', result);
@@ -320,8 +344,8 @@ private class MethodSpyTest {
     sut.whenCalledWith('Expected Param 2').thenReturn('Expected Result 2');
 
     // Act
-    Object result1 = sut.call(new List<Object>{ 'Expected Param 1' });
-    Object result2 = sut.call(new List<Object>{ 'Expected Param 2' });
+    Object result1 = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'Expected Param 1' });
+    Object result2 = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'Expected Param 2' });
 
     // Assert
     Assert.areEqual('Expected Result 1', result1);
@@ -335,7 +359,11 @@ private class MethodSpyTest {
     sut.whenCalledWith('Expected First Param', true).thenReturn('Expected Result');
 
     // Act
-    Object result = sut.call(new List<Object>{ 'Expected First Param', true });
+    Object result = sut.call(
+      new List<Type>{ String.class, Boolean.class },
+      new List<String>{ 'param', 'bool' },
+      new List<Object>{ 'Expected First Param', true }
+    );
 
     // Assert
     Assert.areEqual('Expected Result', result);
@@ -348,7 +376,7 @@ private class MethodSpyTest {
     sut.whenCalledWith(Argument.ofType(Account.getSObjectType()), true).thenReturn('Expected Result');
 
     // Act
-    Object result = sut.call(new List<Object>{ new Account(), true });
+    Object result = sut.call(new List<Type>{ Account.class, Boolean.class }, new List<String>{ 'account', 'bool' }, new List<Object>{ new Account(), true });
 
     // Assert
     Assert.areEqual('Expected Result', result);
@@ -362,7 +390,11 @@ private class MethodSpyTest {
 
     // Act
     try {
-      Object result = sut.call(new List<Object>{ new Opportunity(), true });
+      Object result = sut.call(
+        new List<Type>{ Opportunity.class, Boolean.class },
+        new List<String>{ 'oppy', 'bool' },
+        new List<Object>{ new Opportunity(), true }
+      );
       // Assert
       Assert.fail('it shoud not reach this line');
     } catch (Exception ex) {
@@ -378,8 +410,16 @@ private class MethodSpyTest {
     sut.whenCalledWith('Expected First Param 2', false).thenReturn('Expected Result 2');
 
     // Act
-    Object result1 = sut.call(new List<Object>{ 'Expected First Param 1', true });
-    Object result2 = sut.call(new List<Object>{ 'Expected First Param 2', false });
+    Object result1 = sut.call(
+      new List<Type>{ String.class, Boolean.class },
+      new List<String>{ 'param', 'bool' },
+      new List<Object>{ 'Expected First Param 1', true }
+    );
+    Object result2 = sut.call(
+      new List<Type>{ String.class, Boolean.class },
+      new List<String>{ 'param', 'bool' },
+      new List<Object>{ 'Expected First Param 2', false }
+    );
 
     // Assert
     Assert.areEqual('Expected Result 1', result1);
@@ -392,7 +432,7 @@ private class MethodSpyTest {
     MethodSpy sut = new MethodSpy('methodName');
 
     // Act
-    object actual = sut.call(new List<Object>{});
+    object actual = sut.call(new List<Type>{}, new List<String>{}, new List<Object>{});
 
     // Assert
     Assert.areEqual(null, actual);
@@ -426,8 +466,12 @@ private class MethodSpyTest {
     sut.returns('Default Result');
 
     // Act
-    Object result1 = sut.call(new List<Object>{ 'Expected First Param', true });
-    Object result2 = sut.call(new List<Object>{ 'Another Param', false });
+    Object result1 = sut.call(
+      new List<Type>{ String.class, Boolean.class },
+      new List<String>{ 'param', 'bool' },
+      new List<Object>{ 'Expected First Param', true }
+    );
+    Object result2 = sut.call(new List<Type>{ String.class, Boolean.class }, new List<String>{ 'param', 'bool' }, new List<Object>{ 'Another Param', false });
 
     // Assert
     Assert.areEqual('Expected Result', result1);
@@ -442,8 +486,12 @@ private class MethodSpyTest {
     sut.whenCalledWith('Expected First Param', true).thenReturn('Expected Result');
 
     // Act
-    Object result1 = sut.call(new List<Object>{ 'Expected First Param', true });
-    Object result2 = sut.call(new List<Object>{ 'Another Param', false });
+    Object result1 = sut.call(
+      new List<Type>{ String.class, Boolean.class },
+      new List<String>{ 'param', 'bool' },
+      new List<Object>{ 'Expected First Param', true }
+    );
+    Object result2 = sut.call(new List<Type>{ String.class, Boolean.class }, new List<String>{ 'param', 'bool' }, new List<Object>{ 'Another Param', false });
 
     // Assert
     Assert.areEqual('Expected Result', result1);
@@ -458,7 +506,7 @@ private class MethodSpyTest {
     sut.whenCalledWith(param).thenReturn(new Account());
 
     // Act
-    Object actual = sut.call(new List<Object>{ param });
+    Object actual = sut.call(new List<Type>{ CustomApex.class }, new List<String>{ 'customType' }, new List<Object>{ param });
 
     // Assert
     Object expected = new Account();
@@ -474,7 +522,7 @@ private class MethodSpyTest {
 
     // Act
     try {
-      Object actual = sut.call(new List<Object>{ new Account() });
+      Object actual = sut.call(new List<Type>{ Account.class }, new List<String>{ 'account' }, new List<Object>{ new Account() });
 
       // Assert
       Assert.fail('Expected exception was not thrown');
@@ -491,7 +539,7 @@ private class MethodSpyTest {
     sut.whenCalledWith(param).thenReturn(new Account());
 
     // Act
-    Object actual = sut.call(new List<Object>{ param });
+    Object actual = sut.call(new List<Type>{ CustomApexWithEquals.class }, new List<String>{ 'customType' }, new List<Object>{ param });
 
     // Assert
     Object expected = new Account();
@@ -506,7 +554,7 @@ private class MethodSpyTest {
     sut.whenCalledWith(param).thenReturn(new Account());
 
     // Act
-    Object actual = sut.call(new List<Object>{ param });
+    Object actual = sut.call(new List<Type>{ NotSerializableCustomApex.class }, new List<String>{ 'customType' }, new List<Object>{ param });
 
     // Assert
     Object expected = new Account();
@@ -522,15 +570,15 @@ private class MethodSpyTest {
     sut.whenCalledWith(2).thenReturn('result 2');
 
     // Act & Assert
-    Object result1 = sut.call(new List<Object>{ 1 });
+    Object result1 = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 1 });
     Assert.areEqual('result 1', result1);
 
     // Act & Assert
-    Object result2 = sut.call(new List<Object>{ 2 });
+    Object result2 = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 2 });
     Assert.areEqual('result 2', result2);
 
     // Act & Assert
-    Object resultDefault = sut.call(new List<Object>{ 3 });
+    Object resultDefault = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 3 });
     Assert.areEqual('result default', resultDefault);
   }
 
@@ -543,7 +591,7 @@ private class MethodSpyTest {
 
     // Act & Assert
     try {
-      sut.call(new List<Object>{ 1 });
+      sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 1 });
       Assert.fail('Expected exception was not thrown');
     } catch (Exception e) {
       Assert.areEqual('test exception', e.getMessage());
@@ -558,7 +606,7 @@ private class MethodSpyTest {
     sut.returns('result');
 
     // Act
-    Object result = sut.call(new List<Object>{ 1 });
+    Object result = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 1 });
 
     // Assert
     Assert.areEqual('result', result);
@@ -573,15 +621,15 @@ private class MethodSpyTest {
     sut.returns('result default');
 
     // Act & Assert
-    Object result1 = sut.call(new List<Object>{ 1 });
+    Object result1 = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 1 });
     Assert.areEqual('result 1', result1);
 
     // Act & Assert
-    Object result2 = sut.call(new List<Object>{ 2 });
+    Object result2 = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 2 });
     Assert.areEqual('result 2', result2);
 
     // Act & Assert
-    Object resultDefault = sut.call(new List<Object>{ 3 });
+    Object resultDefault = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 3 });
     Assert.areEqual('result default', resultDefault);
   }
 
@@ -594,16 +642,16 @@ private class MethodSpyTest {
     sut.whenCalledWith(2).thenReturn('result 2');
 
     // Act & Assert
-    Object result1 = sut.call(new List<Object>{ 1 });
+    Object result1 = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 1 });
     Assert.areEqual('result 1', result1);
 
     // Act & Assert
-    Object result2 = sut.call(new List<Object>{ 2 });
+    Object result2 = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 2 });
     Assert.areEqual('result 2', result2);
 
     // Act & Assert
     try {
-      sut.call(new List<Object>{ 3 });
+      sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 3 });
       Assert.fail('Expected exception was not thrown');
     } catch (Exception e) {
       Assert.areEqual('test exception', e.getMessage());
@@ -619,16 +667,16 @@ private class MethodSpyTest {
     sut.throwsException(new IllegalArgumentException('test exception'));
 
     // Act & Assert
-    Object result1 = sut.call(new List<Object>{ 1 });
+    Object result1 = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 1 });
     Assert.areEqual('result 1', result1);
 
     // Act & Assert
-    Object result2 = sut.call(new List<Object>{ 2 });
+    Object result2 = sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 2 });
     Assert.areEqual('result 2', result2);
 
     // Act & Assert
     try {
-      sut.call(new List<Object>{ 3 });
+      sut.call(new List<Type>{ Integer.class }, new List<String>{ 'count' }, new List<Object>{ 3 });
       Assert.fail('Expected exception was not thrown');
     } catch (Exception e) {
       Assert.areEqual('test exception', e.getMessage());

--- a/force-app/test/package/classes/unit/deprecated/DeprecatedMethodSpyTest.cls
+++ b/force-app/test/package/classes/unit/deprecated/DeprecatedMethodSpyTest.cls
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+@IsTest
+private class DeprecatedMethodSpyTest {
+  @IsTest
+  static void givenSpyConfiguredOnceToReturnOnMatchingArguments_whenCallingDeprecatedCall_whenCallingTheSpyWithOtherArguments_itThrowsMethodSpyConfigurationException() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.whenCalledWith('Another Param', true).thenReturn('Expected Result');
+    sut.whenCalledWith('Expected First Param', false).thenReturn('Another expected Result');
+    sut.whenCalledWith('Expected First Param', true).thenReturn('Yet another expected Result');
+    try {
+      // Act
+      sut.call(new List<Object>{ 'Another Param', false });
+      Assert.fail('it shoud not reach this line');
+    } catch (MethodSpy.ConfigurationException cex) {
+      // Assert
+      Assert.areEqual(
+        'No stub value found for a call of methodName(String <unknown_param_name>[Another Param], Boolean <unknown_param_name>[false])\nHere are the configured stubs:\n\twhenCalledWith(Another Param, true).thenReturn(Expected Result)\n\twhenCalledWith(Expected First Param, false).thenReturn(Another expected Result)\n\twhenCalledWith(Expected First Param, true).thenReturn(Yet another expected Result)',
+        cex.getMessage()
+      );
+    }
+  }
+}

--- a/force-app/test/package/classes/unit/deprecated/DeprecatedMethodSpyTest.cls-meta.xml
+++ b/force-app/test/package/classes/unit/deprecated/DeprecatedMethodSpyTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add names and types of method parameters when `ConfigurationExceptionBuilder` creates the `ConfigurationException`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improve the debugging experience

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Spec changed and prototype change propagated
