### PR TITLE
fix: spy calls with newer SObjects (and misc. updates)

### DIFF
--- a/force-app/recipes/classes/ApexMockeryOverview.cls-meta.xml
+++ b/force-app/recipes/classes/ApexMockeryOverview.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/OperaPastryMatchable.cls-meta.xml
+++ b/force-app/recipes/classes/OperaPastryMatchable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/asserting/HasBeenCalled.cls-meta.xml
+++ b/force-app/recipes/classes/asserting/HasBeenCalled.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/asserting/HasBeenCalledTimes.cls-meta.xml
+++ b/force-app/recipes/classes/asserting/HasBeenCalledTimes.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/asserting/HasBeenCalledWith.cls-meta.xml
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWith.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithCustomMatchable.cls-meta.xml
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithCustomMatchable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithJSONMatchable.cls-meta.xml
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithJSONMatchable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/asserting/HasBeenCalledWithTypeMatchable.cls-meta.xml
+++ b/force-app/recipes/classes/asserting/HasBeenCalledWithTypeMatchable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/asserting/HasBeenLastCalledWith.cls-meta.xml
+++ b/force-app/recipes/classes/asserting/HasBeenLastCalledWith.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/asserting/HasNotBeenCalled.cls-meta.xml
+++ b/force-app/recipes/classes/asserting/HasNotBeenCalled.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/NoConfiguration.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/NoConfiguration.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/Returns.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/Returns.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/ReturnsThenThrows.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/ReturnsThenThrows.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/Throws.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/Throws.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/ThrowsThenReturns.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/ThrowsThenReturns.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWithCustomMatchable_ThenReturn.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWithCustomMatchable_ThenReturn.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWithEqualMatching_ThenReturn.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWithEqualMatching_ThenReturn.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWithJSONMatching_ThenReturn.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWithJSONMatching_ThenReturn.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWithMatchingThrowsAndReturns.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWithMatchingThrowsAndReturns.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWithNotMatchingAndReturn.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWithNotMatchingAndReturn.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWithTypeMatching_ThenReturn.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWithTypeMatching_ThenReturn.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrow.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrow.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWithoutMatchingConfiguration.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWithoutMatchingConfiguration.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/setup/Bakery.cls-meta.xml
+++ b/force-app/recipes/classes/setup/Bakery.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/setup/DeliveryService.cls-meta.xml
+++ b/force-app/recipes/classes/setup/DeliveryService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/setup/OrderConfirmation.cls-meta.xml
+++ b/force-app/recipes/classes/setup/OrderConfirmation.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/setup/Pastry.cls-meta.xml
+++ b/force-app/recipes/classes/setup/Pastry.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/recipes/classes/setup/RecipeException.cls-meta.xml
+++ b/force-app/recipes/classes/setup/RecipeException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -6,7 +6,7 @@
  */
 
 /**
- * Matchable offers publis static methods to build out-of-the-box matchers to be used with Expect
+ * Matchable offers public static methods to build out-of-the-box matchers to be used with Expect
  *    - Argument.any()
  *    - Argument.equals(Object object)
  *    - Argument.jsonEquals(Object object)
@@ -15,7 +15,7 @@
  *    - Argument.ofType(Schema.SObjectType sobjectType)
  */
 @IsTest
-@SuppressWarnings('PMD.EmptyStatementBlock')
+@SuppressWarnings('PMD.EmptyStatementBlock, PMD.AvoidGlobalModifier')
 global class Argument {
   global interface Matchable {
     Boolean matches(Object callArgument);
@@ -192,7 +192,7 @@ global class Argument {
     private String getType(final Object callArgument) {
       String result = 'Date';
       try {
-        Date typeCheck = (Date) callArgument;
+        Date.valueOf(callArgument);
       } catch (System.TypeException te) {
         String message = te.getMessage().substringAfter('Invalid conversion from runtime type ');
         result = message.substringBefore(' to Date');

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -149,8 +149,7 @@ global class Argument {
     }
 
     public override String toString() {
-      // This should not use the serialized JSON, which would cause a mismatch for whenCalledWith checks.
-      return String.valueOf(callArgumentToMatch); 
+      return 'json(' + this.callArgumentToMatch + ')'; 
     }
   }
 

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -127,7 +127,11 @@ global class Argument {
     }
 
     public Boolean matches(final Object callArgument) {
-      return this.callArgumentToMatch == callArgument;
+      if (this.callArgumentToMatch == null) {
+        return callArgument == null;
+      }
+
+      return this.callArgumentToMatch.equals(callArgument);
     }
 
     public override String toString() {
@@ -145,7 +149,11 @@ global class Argument {
     }
 
     public Boolean matches(final Object callArgument) {
-      return this.jsonValue == JSON.serialize(callArgument);
+      if (this.jsonValue == null) {
+        return callArgument == null;
+      }
+
+      return this.jsonValue.equals(JSON.serialize(callArgument));
     }
 
     public override String toString() {

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -149,10 +149,6 @@ global class Argument {
     }
 
     public Boolean matches(final Object callArgument) {
-      if (this.jsonValue == null) {
-        return callArgument == null;
-      }
-
       return this.jsonValue.equals(JSON.serialize(callArgument));
     }
 

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -170,7 +170,7 @@ global class Argument {
 
     public boolean matches(final Object callArgument) {
       String typeName = this.getType(callArgument);
-      // This is a case-insensitive check and should remain that way.
+      // Using a case-insensitive comparison since Apex types are case-insensitive
       if (this.typeNameToMatch == typeName) {
         return true;
       }
@@ -185,16 +185,13 @@ global class Argument {
 
     private String getType(final Object callArgument) {
       try {
-        castToDate(callArgument);
+        // Cast as Date to determine if Object is a valid Date.
+        Date typeCheck = (Date) callArgument; // NOPMD
         return 'Date';
       } catch (System.TypeException te) {
+        // If not a Date, extract Type output from exception message.
         return te.getMessage().substringBetween('Invalid conversion from runtime type ', ' to Date');
       }
-    }
-
-    // Date.valueOf() does not work. Use method to avoid assigning to unused variable.
-    private Date castToDate(final Object callArgument) {
-      return (Date) callArgument;
     }
 
     public override String toString() {

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -89,7 +89,11 @@ global class Argument {
 
   private static Boolean isJSON(Object callArgument) {
     try {
-      return JSON.serialize(callArgument)?.startsWith('{') == true;
+      String serializedCallArgument =  JSON.serialize(callArgument);
+      if (serializedCallArgument == null) {
+        return false;
+      }
+      return serializedCallArgument.startsWith('{') && serializedCallArgument.endsWith('}');
     } catch (JSONException e) {
       return false; 
     }
@@ -137,7 +141,7 @@ global class Argument {
     }
 
     public Boolean matches(final Object callArgument) {
-      return callArgument == this.callArgumentToMatch;
+      return this.callArgumentToMatch == callArgument;
     }
 
     public override String toString() {

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -78,11 +78,21 @@ global class Argument {
     for (Object callArgument : listOfArgs) {
       if (callArgument instanceof Argument.Matchable) {
         listOfMatchableArgs.add((Argument.Matchable) callArgument);
+      } else if (isJSON(callArgument)) { 
+        listOfMatchableArgs.add(Argument.jsonEquals(callArgument));
       } else {
         listOfMatchableArgs.add(Argument.equals(callArgument));
       }
     }
     return listOfMatchableArgs;
+  }
+
+  private static Boolean isJSON(Object callArgument) {
+    try {
+      return JSON.serialize(callArgument)?.startsWith('{') == true;
+    } catch (JSONException e) {
+      return false; 
+    }
   }
 
   global static Argument.Matchable any() {
@@ -127,35 +137,30 @@ global class Argument {
     }
 
     public Boolean matches(final Object callArgument) {
-      if (this.callArgumentToMatch == null && callArgument == null) {
-        return true;
-      }
-
-      if (this.callArgumentToMatch != null) {
-        return this.callArgumentToMatch.equals(callArgument);
-      }
-
-      return false;
+      return callArgument == this.callArgumentToMatch;
     }
 
     public override String toString() {
-      return String.valueOf(this.callArgumentToMatch);
+      return String.valueOf(callArgumentToMatch);
     }
   }
 
   private class JSONMatchable implements Argument.Matchable {
+    private Object callArgumentToMatch;
     private String jsonValue;
 
     public JSONMatchable(final Object callArgumentToMatch) {
+      this.callArgumentToMatch = callArgumentToMatch;
       this.jsonValue = JSON.serialize(callArgumentToMatch);
     }
 
-    public boolean matches(final Object callArgument) {
+    public Boolean matches(final Object callArgument) {
       return this.jsonValue == JSON.serialize(callArgument);
     }
 
     public override String toString() {
-      return 'json(' + this.jsonValue + ')';
+      // This should not use the serialized JSON, which would cause a mismatch for whenCalledWith checks.
+      return String.valueOf(callArgumentToMatch); 
     }
   }
 
@@ -192,7 +197,7 @@ global class Argument {
     private String getType(final Object callArgument) {
       String result = 'Date';
       try {
-        Date.valueOf(callArgument);
+        Date typeCheck = (Date) callArgument;
       } catch (System.TypeException te) {
         String message = te.getMessage().substringAfter('Invalid conversion from runtime type ');
         result = message.substringBefore(' to Date');
@@ -201,7 +206,7 @@ global class Argument {
     }
 
     public override String toString() {
-      return this.typeNameToMatch + '.Type';
+      return typeNameToMatch + '.Type';
     }
   }
 }

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -131,7 +131,7 @@ global class Argument {
     }
 
     public override String toString() {
-      return String.valueOf(callArgumentToMatch);
+      return String.valueOf(this.callArgumentToMatch);
     }
   }
 
@@ -198,7 +198,7 @@ global class Argument {
     }
 
     public override String toString() {
-      return typeNameToMatch + '.Type';
+      return this.typeNameToMatch + '.Type';
     }
   }
 }

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -127,7 +127,7 @@ global class Argument {
     }
 
     public Boolean matches(final Object callArgument) {
-      return callArgument == this.callArgumentToMatch;
+      return String.valueOf(callArgument).equals(this.toString());
     }
 
     override public String toString() {

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -131,7 +131,13 @@ global class Argument {
         return callArgument == null;
       }
 
-      return this.callArgumentToMatch.equals(callArgument);
+      // case-sensitive check for string
+      if (this.callArgumentToMatch instanceof String) {
+        return this.callArgumentToMatch.equals(callArgument);
+      }
+
+      // native platform equality check for anything else
+      return this.callArgumentToMatch == callArgument;
     }
 
     public override String toString() {

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -114,7 +114,7 @@ global class Argument {
       return true;
     }
 
-    override public String toString() {
+    public override String toString() {
       return 'any';
     }
   }
@@ -127,20 +127,26 @@ global class Argument {
     }
 
     public Boolean matches(final Object callArgument) {
-      return String.valueOf(callArgument) == this.toString();
+      if (this.callArgumentToMatch == null && callArgument == null) {
+        return true;
+      }
+
+      if (this.callArgumentToMatch != null) {
+        return this.callArgumentToMatch.equals(callArgument);
+      }
+
+      return false;
     }
 
-    override public String toString() {
-      return callArgumentToMatch + '';
+    public override String toString() {
+      return String.valueOf(this.callArgumentToMatch);
     }
   }
 
   private class JSONMatchable implements Argument.Matchable {
-    private Object callArgumentToMatch;
     private String jsonValue;
 
     public JSONMatchable(final Object callArgumentToMatch) {
-      this.callArgumentToMatch = callArgumentToMatch;
       this.jsonValue = JSON.serialize(callArgumentToMatch);
     }
 
@@ -148,34 +154,35 @@ global class Argument {
       return this.jsonValue == JSON.serialize(callArgument);
     }
 
-    override public String toString() {
-      return 'json(' + callArgumentToMatch + ')';
+    public override String toString() {
+      return 'json(' + this.jsonValue + ')';
     }
   }
 
   private class TypeMatchable implements Argument.Matchable {
-    private String callArgumentToMatch;
+    private String typeNameToMatch;
 
     public TypeMatchable(final Schema.SObjectType callArgumentToMatch) {
-      this.callArgumentToMatch = callArgumentToMatch.getDescribe().getName();
+      this.typeNameToMatch = callArgumentToMatch.getDescribe().getName();
     }
 
     public TypeMatchable(final String callArgumentToMatch) {
-      this.callArgumentToMatch = callArgumentToMatch;
+      this.typeNameToMatch = callArgumentToMatch;
     }
 
     public TypeMatchable(final Type callArgumentToMatch) {
-      this.callArgumentToMatch = callArgumentToMatch.getName();
+      this.typeNameToMatch = callArgumentToMatch.getName();
     }
 
     public boolean matches(final Object callArgument) {
       String typeName = this.getType(callArgument);
-      if (this.callArgumentToMatch == typeName) {
+      // This is a case-insensitive check and should remain that way.
+      if (this.typeNameToMatch == typeName) {
         return true;
       }
 
       Type actualType = Type.forName(typeName);
-      Type expectedType = Type.forName(this.callArgumentToMatch);
+      Type expectedType = Type.forName(this.typeNameToMatch);
       if (expectedType != null && actualType != null) {
         return expectedType.isAssignableFrom(actualType);
       }
@@ -193,8 +200,8 @@ global class Argument {
       return result;
     }
 
-    override public String toString() {
-      return callArgumentToMatch + '.Type';
+    public override String toString() {
+      return this.typeNameToMatch + '.Type';
     }
   }
 }

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -78,25 +78,11 @@ global class Argument {
     for (Object callArgument : listOfArgs) {
       if (callArgument instanceof Argument.Matchable) {
         listOfMatchableArgs.add((Argument.Matchable) callArgument);
-      } else if (isJSON(callArgument)) { 
-        listOfMatchableArgs.add(Argument.jsonEquals(callArgument));
       } else {
         listOfMatchableArgs.add(Argument.equals(callArgument));
       }
     }
     return listOfMatchableArgs;
-  }
-
-  private static Boolean isJSON(Object callArgument) {
-    try {
-      String serializedCallArgument =  JSON.serialize(callArgument);
-      if (serializedCallArgument == null) {
-        return false;
-      }
-      return serializedCallArgument.startsWith('{') && serializedCallArgument.endsWith('}');
-    } catch (JSONException e) {
-      return false; 
-    }
   }
 
   global static Argument.Matchable any() {
@@ -199,14 +185,17 @@ global class Argument {
     }
 
     private String getType(final Object callArgument) {
-      String result = 'Date';
       try {
-        Date typeCheck = (Date) callArgument;
+        castToDate(callArgument);
+        return 'Date';
       } catch (System.TypeException te) {
-        String message = te.getMessage().substringAfter('Invalid conversion from runtime type ');
-        result = message.substringBefore(' to Date');
+        return te.getMessage().substringBetween('Invalid conversion from runtime type ', ' to Date');
       }
-      return result;
+    }
+
+    // Date.valueOf() does not work. Use method to avoid assigning to unused variable.
+    private Date castToDate(final Object callArgument) {
+      return (Date) callArgument;
     }
 
     public override String toString() {

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -127,7 +127,7 @@ global class Argument {
     }
 
     public Boolean matches(final Object callArgument) {
-      return String.valueOf(callArgument).equals(this.toString());
+      return String.valueOf(callArgument) == this.toString();
     }
 
     override public String toString() {

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -159,7 +159,7 @@ global class Argument {
     }
 
     public override String toString() {
-      return 'json(' + this.callArgumentToMatch + ')'; 
+      return 'json(' + this.callArgumentToMatch + ')';
     }
   }
 

--- a/force-app/src/classes/Argument.cls-meta.xml
+++ b/force-app/src/classes/Argument.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/src/classes/Expect.cls-meta.xml
+++ b/force-app/src/classes/Expect.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/src/classes/MethodSpy.cls-meta.xml
+++ b/force-app/src/classes/MethodSpy.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/src/classes/Mock.cls-meta.xml
+++ b/force-app/src/classes/Mock.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/namespace/classes/ApexMockeryOverview.cls-meta.xml
+++ b/force-app/test/namespace/classes/ApexMockeryOverview.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/namespace/classes/utils/StubBuilderImpl.cls-meta.xml
+++ b/force-app/test/namespace/classes/utils/StubBuilderImpl.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/package/classes/functional/BusinessService.cls-meta.xml
+++ b/force-app/test/package/classes/functional/BusinessService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/package/classes/functional/DMLDelegate.cls-meta.xml
+++ b/force-app/test/package/classes/functional/DMLDelegate.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/package/classes/functional/FunctionalTest.cls-meta.xml
+++ b/force-app/test/package/classes/functional/FunctionalTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -75,9 +75,9 @@ public class ArgumentTest {
   }
 
   @isTest
-  static void givenEqualsMatchable_matchesCustomTypeWithEqualsAndProperties() {
+  static void givenEqualsMatchable_matchesCustomTypeWithEquals() {
     // Arrange
-    Argument.Matchable sut = Argument.jsonEquals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
+    Argument.Matchable sut = Argument.equals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
 
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
@@ -97,31 +97,8 @@ public class ArgumentTest {
     Assert.isFalse(sut.matches(new List<Object>()));
     Assert.isFalse(sut.matches(new Set<Object>()));
     Assert.isFalse(sut.matches(new Map<Id, Object>()));
-  }
-
-  @isTest
-  static void givenEqualsMatchable_matchesCustomTypeWithoutProperties() {
-    // Arrange
-    Argument.Matchable sut = Argument.jsonEquals(new CustomType());
-
-    // Act & Assert
-    Assert.isTrue(sut.matches(new CustomType()));
-
-    Assert.isFalse(sut.matches(null));
-    Assert.isFalse(sut.matches(Date.today()));
-    Assert.isFalse(sut.matches(DateTime.now()));
-    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
-    Assert.isFalse(sut.matches(Blob.valueOf('test')));
-    Assert.isFalse(sut.matches(false));
-    Assert.isFalse(sut.matches(true));
-    Assert.isFalse(sut.matches(new Account(Name = 'test')));
-    Assert.isFalse(sut.matches(10));
-    Assert.isFalse(sut.matches(10.2));
-    Assert.isFalse(sut.matches('test'));
-    Assert.isFalse(sut.matches('001000000000011AAA'));
-    Assert.isFalse(sut.matches(new List<Object>()));
-    Assert.isFalse(sut.matches(new Set<Object>()));
-    Assert.isFalse(sut.matches(new Map<Id, Object>()));
+    // TODO: Why did we not want this to match?
+    // Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -81,7 +81,7 @@ public class ArgumentTest {
 
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
-    
+    Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
     Assert.isFalse(sut.matches(null));
     Assert.isFalse(sut.matches(Date.today()));
     Assert.isFalse(sut.matches(DateTime.now()));

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -75,9 +75,9 @@ public class ArgumentTest {
   }
 
   @isTest
-  static void givenEqualsMatchable_matchesCustomTypeWithProperties() {
+  static void givenEqualsMatchable_matchesCustomTypeWithEqualsAndProperties() {
     // Arrange
-    Argument.Matchable sut = Argument.equals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
+    Argument.Matchable sut = Argument.jsonEquals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
 
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
@@ -97,13 +97,12 @@ public class ArgumentTest {
     Assert.isFalse(sut.matches(new List<Object>()));
     Assert.isFalse(sut.matches(new Set<Object>()));
     Assert.isFalse(sut.matches(new Map<Id, Object>()));
-    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
   static void givenEqualsMatchable_matchesCustomTypeWithoutProperties() {
     // Arrange
-    Argument.Matchable sut = Argument.equals(new CustomType());
+    Argument.Matchable sut = Argument.jsonEquals(new CustomType());
 
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomType()));
@@ -123,7 +122,6 @@ public class ArgumentTest {
     Assert.isFalse(sut.matches(new List<Object>()));
     Assert.isFalse(sut.matches(new Set<Object>()));
     Assert.isFalse(sut.matches(new Map<Id, Object>()));
-    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -304,8 +304,6 @@ public class ArgumentTest {
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
 
-    // TODO: Fix this. It still fails.
-
     Assert.isFalse(sut.matches(null));
     Assert.isFalse(sut.matches(Date.today()));
     Assert.isFalse(sut.matches(DateTime.now()));

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -374,6 +374,7 @@ public class ArgumentTest {
         return true;
       }
 
+      // Must do instanceof check for Boolean BEFORE CustomType or else SF will GACK on `(CustomType) o`
       if (o == null || o instanceof Boolean || !(o instanceof CustomType)) {
         return false;
       }

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -82,6 +82,7 @@ public class ArgumentTest {
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
     Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
+
     Assert.isFalse(sut.matches(null));
     Assert.isFalse(sut.matches(Date.today()));
     Assert.isFalse(sut.matches(DateTime.now()));
@@ -97,6 +98,8 @@ public class ArgumentTest {
     Assert.isFalse(sut.matches(new List<Object>()));
     Assert.isFalse(sut.matches(new Set<Object>()));
     Assert.isFalse(sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(new CustomType('TEST', 10, new Account(Name = 'TEST'))));
+    Assert.isFalse(sut.matches(new CustomTypeWithEquals('TEST', 10, new Account(Name = 'TEST'))));
   }
 
   @isTest

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -81,12 +81,13 @@ public class ArgumentTest {
 
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
-
+    
     Assert.isFalse(sut.matches(null));
     Assert.isFalse(sut.matches(Date.today()));
     Assert.isFalse(sut.matches(DateTime.now()));
     Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
     Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    /*
     Assert.isFalse(sut.matches(false));
     Assert.isFalse(sut.matches(true));
     Assert.isFalse(sut.matches(new Account(Name = 'test')));
@@ -97,8 +98,8 @@ public class ArgumentTest {
     Assert.isFalse(sut.matches(new List<Object>()));
     Assert.isFalse(sut.matches(new Set<Object>()));
     Assert.isFalse(sut.matches(new Map<Id, Object>()));
-    // TODO: Why did we not want this to match?
-    // Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+    */
   }
 
   @isTest
@@ -373,7 +374,7 @@ public class ArgumentTest {
         return true;
       }
 
-      if ((o == null) || !(o instanceof CustomType)) {
+      if (o == null || o instanceof Boolean || !(o instanceof CustomType)) {
         return false;
       }
 

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -82,24 +82,25 @@ public class ArgumentTest {
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
     
+    // TODO: Fix commented out asserts; they throw a GACK if uncommented.
     Assert.isFalse(sut.matches(null));
     Assert.isFalse(sut.matches(Date.today()));
     Assert.isFalse(sut.matches(DateTime.now()));
     Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
     Assert.isFalse(sut.matches(Blob.valueOf('test')));
-    /*
-    Assert.isFalse(sut.matches(false));
-    Assert.isFalse(sut.matches(true));
+    // Assert.isFalse(sut.matches(false));
+    // Assert.isFalse(sut.matches(true));
     Assert.isFalse(sut.matches(new Account(Name = 'test')));
-    Assert.isFalse(sut.matches(10));
+    // Assert.isFalse(sut.matches(10));
     Assert.isFalse(sut.matches(10.2));
     Assert.isFalse(sut.matches('test'));
     Assert.isFalse(sut.matches('001000000000011AAA'));
     Assert.isFalse(sut.matches(new List<Object>()));
     Assert.isFalse(sut.matches(new Set<Object>()));
     Assert.isFalse(sut.matches(new Map<Id, Object>()));
-    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
-    */
+
+    // TODO: Fix this. It still fails.
+    // Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
@@ -374,8 +375,7 @@ public class ArgumentTest {
         return true;
       }
 
-      // Must do instanceof check for Boolean BEFORE CustomType or else SF will GACK on `(CustomType) o`
-      if (o == null || o instanceof Boolean || !(o instanceof CustomType)) {
+      if ((o == null) || !(o instanceof CustomType)) {
         return false;
       }
 

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -75,12 +75,38 @@ public class ArgumentTest {
   }
 
   @isTest
-  static void givenEqualsMatchable_matchesCustomType() {
+  static void givenEqualsMatchable_matchesCustomTypeWithProperties() {
     // Arrange
     Argument.Matchable sut = Argument.equals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
 
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
+
+    Assert.isFalse(sut.matches(null));
+    Assert.isFalse(sut.matches(Date.today()));
+    Assert.isFalse(sut.matches(DateTime.now()));
+    Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
+    Assert.isFalse(sut.matches(Blob.valueOf('test')));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(new Account(Name = 'test')));
+    Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10.2));
+    Assert.isFalse(sut.matches('test'));
+    Assert.isFalse(sut.matches('001000000000011AAA'));
+    Assert.isFalse(sut.matches(new List<Object>()));
+    Assert.isFalse(sut.matches(new Set<Object>()));
+    Assert.isFalse(sut.matches(new Map<Id, Object>()));
+    Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+  }
+
+  @isTest
+  static void givenEqualsMatchable_matchesCustomTypeWithoutProperties() {
+    // Arrange
+    Argument.Matchable sut = Argument.equals(new CustomType());
+
+    // Act & Assert
+    Assert.isTrue(sut.matches(new CustomType()));
 
     Assert.isFalse(sut.matches(null));
     Assert.isFalse(sut.matches(Date.today()));

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -82,16 +82,15 @@ public class ArgumentTest {
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
     
-    // TODO: Fix commented out asserts; they throw a GACK if uncommented.
     Assert.isFalse(sut.matches(null));
     Assert.isFalse(sut.matches(Date.today()));
     Assert.isFalse(sut.matches(DateTime.now()));
     Assert.isFalse(sut.matches(Time.newInstance(12, 12, 12, 12)));
     Assert.isFalse(sut.matches(Blob.valueOf('test')));
-    // Assert.isFalse(sut.matches(false));
-    // Assert.isFalse(sut.matches(true));
+    Assert.isFalse(sut.matches(false));
+    Assert.isFalse(sut.matches(true));
     Assert.isFalse(sut.matches(new Account(Name = 'test')));
-    // Assert.isFalse(sut.matches(10));
+    Assert.isFalse(sut.matches(10));
     Assert.isFalse(sut.matches(10.2));
     Assert.isFalse(sut.matches('test'));
     Assert.isFalse(sut.matches('001000000000011AAA'));

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -80,7 +80,7 @@ public class ArgumentTest {
     Argument.Matchable sut = Argument.equals(new CustomTypeWithEquals('test', 10, new Account(Name = 'test')));
 
     // Act & Assert
-    Assert.isTrue(sut.matches(new CustomTypeWithEquals('test', 10, new Account(Name = 'test'))));
+    Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
     
     // TODO: Fix commented out asserts; they throw a GACK if uncommented.
     Assert.isFalse(sut.matches(null));
@@ -98,9 +98,6 @@ public class ArgumentTest {
     Assert.isFalse(sut.matches(new List<Object>()));
     Assert.isFalse(sut.matches(new Set<Object>()));
     Assert.isFalse(sut.matches(new Map<Id, Object>()));
-
-    // TODO: Fix this. It still fails.
-    // Assert.isFalse(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
   }
 
   @isTest
@@ -307,6 +304,8 @@ public class ArgumentTest {
 
     // Act & Assert
     Assert.isTrue(sut.matches(new CustomType('test', 10, new Account(Name = 'test'))));
+
+    // TODO: Fix this. It still fails.
 
     Assert.isFalse(sut.matches(null));
     Assert.isFalse(sut.matches(Date.today()));

--- a/force-app/test/package/classes/unit/ArgumentTest.cls-meta.xml
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/package/classes/unit/DummyInterface.cls-meta.xml
+++ b/force-app/test/package/classes/unit/DummyInterface.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/package/classes/unit/ExpectTest.cls-meta.xml
+++ b/force-app/test/package/classes/unit/ExpectTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/package/classes/unit/MethodSpyTest.cls-meta.xml
+++ b/force-app/test/package/classes/unit/MethodSpyTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/test/package/classes/unit/MockTest.cls-meta.xml
+++ b/force-app/test/package/classes/unit/MockTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
closes #58 

When working on recent tests, I had an issue where mock call arguments was not being matched properly, even when they appeared to be equal. 

EDIT: Further testing revealed this was due to the SObject that was being passed being incompatible with the API version `56.0` of these Apex classes.

<!--- Describe your changes in detail -->

I updated the API versions of all the Apex classes to `61.0`. I also applied various cleanup changes based on feedback from @scolladon.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows this codebase to support recent SObject schema changes from new API versions.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

All the unit tests pass when this project deployed to a scratch org. I also verified that the changes work in the portion of this that I use in my codebase.