### PR TITLE
feat: add "global" and "matching" `once` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ We want its usage to be simple, its maintainability to be easy and to provide th
     - [How to Configure a spy](#how-to-configure-a-spy)
       - [Default behaviour](#default-behaviour)
       - [Global returns](#global-returns)
+      - [Global returns once](#global-returns-once)
       - [Global throws](#global-throws)
+      - [Global throws once](#global-throws-once)
       - [Parameterized configuration](#parameterized-configuration)
       - [Configuration order matters !](#configuration-order-matters-)
   - [Assert on a spy](#assert-on-a-spy)
@@ -155,6 +157,22 @@ Assert.areEqual(new Account(Name='Test'), result);
 
 Have a look at the [Returns recipe](force-app/recipes/classes/mocking/Returns.cls)
 
+##### Global returns once
+
+Configure it to return a specific value once, whatever the parameter received
+The stub will return the configured value once
+
+```java
+// Arrange
+myMethodSpy.returnsOnce(new Account(Name='Test'));
+// Act
+Object result = myTypeStub.myMethod();
+// Assert
+Assert.areEqual(new Account(Name='Test'), result);
+```
+
+Have a look at the [ReturnsOnce recipe](force-app/recipes/classes/mocking/ReturnsOnce.cls)
+
 ##### Global throws
 
 Configure it to throw a specific exception, whatever the parameter received
@@ -176,10 +194,33 @@ try {
 
 Have a look at the [Throws recipe](force-app/recipes/classes/mocking/Throws.cls)
 
+##### Global throws once
+
+Configure it to throw a specific exception once, whatever the parameter received
+The stub will throw the configured exception once
+
+```java
+// Arrange
+myMethodSpy.throwsExceptionOnce(new MyException());
+try {
+    // Act
+    Object result = myTypeStub.myMethod();
+
+    // Assert
+    Assert.fail('Expected exception was not thrown');
+} catch (Exception ex) {
+    Assert.isInstanceOfType(ex, MyException.class);
+}
+```
+
+Have a look at the [ThrowsOnce recipe](force-app/recipes/classes/mocking/ThrowsOnce.cls)
+
 ##### Parameterized configuration
 
 Configure it to return a specific value, when call with specific parameters
+Configure it to return a specific value once, when call with specific parameters
 Configure it to throw a specific value, when call with specific parameters
+Configure it to throw a specific value once, when call with specific parameters
 
 ```java
 // Arrange
@@ -189,8 +230,24 @@ myMethodSpy
 
 // Arrange
 myMethodSpy
+    .whenCalledWith(Argument.any(), 10)
+    .thenReturnOnce(new Account(Name='Test Once'));
+
+// Arrange
+myMethodSpy
     .whenCalledWith(Argument.any(), -1)
     .thenThrow(new MyException);
+
+// Arrange
+myMethodSpy
+    .whenCalledWith(Argument.any(), -1)
+    .thenThrowOnce(new MyOtherException);
+
+// Act
+Object result = myTypeStub.myMethod('nothing', 10);
+
+// Assert
+Assert.areEqual(new Account(Name='Test Once'), result);
 
 // Act
 Object result = myTypeStub.myMethod('nothing', 10);
@@ -200,7 +257,17 @@ Assert.areEqual(new Account(Name='Test'), result);
 
 // Act
 try {
-    Object result = myTypeStub.myMethod('value', -1);
+    myTypeStub.myMethod('value', -1);
+
+    // Assert
+    Assert.fail('Expected exception was not thrown');
+} catch (Exception ex) {
+    Assert.isInstanceOfType(ex, MyOtherException.class);
+}
+
+// Act
+try {
+    myTypeStub.myMethod('value', -1);
 
     // Assert
     Assert.fail('Expected exception was not thrown');

--- a/README.md
+++ b/README.md
@@ -370,8 +370,10 @@ It contains one classe for each use cases the library covers
 
 - [No Configuration](force-app/recipes/classes/mocking/NoConfiguration.cls): spy not configured
 - [Returns](force-app/recipes/classes/mocking/Returns.cls): spy configured to return
+- [Returns](force-app/recipes/classes/mocking/ReturnsOnce.cls): spy configured to return once
 - [ReturnsThenThrows](force-app/recipes/classes/mocking/ReturnsThenThrows.cls): spy configured to throw
 - [Throws](force-app/recipes/classes/mocking/Throws.cls): spy configured to throw
+- [ThrowsOnce](force-app/recipes/classes/mocking/ThrowsOnce.cls): spy configured to throw once
 - [ThrowsThenReturns](force-app/recipes/classes/mocking/ThrowsThenReturns.cls): spy configured to return
 - [WhenCalledWithCustomMatchable_ThenReturn](force-app/recipes/classes/mocking/WhenCalledWithCustomMatchable_ThenReturn.cls): spy configured with custom matcher to return
 - [WhenCalledWithEqualMatching_ThenReturn](force-app/recipes/classes/mocking/WhenCalledWithEqualMatching_ThenReturn.cls): spy configured with equals matcher to return
@@ -379,7 +381,9 @@ It contains one classe for each use cases the library covers
 - [WhenCalledWithMatchingThrowsAndReturns](force-app/recipes/classes/mocking/WhenCalledWithMatchingThrowsAndReturns.cls): spy configured with matcher to return and to throw
 - [WhenCalledWithNotMatchingAndReturn](force-app/recipes/classes/mocking/WhenCalledWithNotMatchingAndReturn.cls): spy configured with matcher and global return, called without matching parameters
 - [WhenCalledWithTypeMatching_ThenReturn](force-app/recipes/classes/mocking/WhenCalledWithTypeMatching_ThenReturn.cls): spy configured with type matcher to return
-- [WhenCalledWith_ThenThrow](force-app/recipes/classes/mocking/WhenCalledWith_ThenThrow.cls): spy configured with JSON matcher to throw
+- [WhenCalledWith_ThenReturnOnce](force-app/recipes/classes/mocking/WhenCalledWith_ThenReturnOnce.cls): spy configured with a matcher to return once
+- [WhenCalledWith_ThenThrow](force-app/recipes/classes/mocking/WhenCalledWith_ThenThrow.cls): spy configured with a matcher to throw
+- [WhenCalledWith_ThenThrowOnce](force-app/recipes/classes/mocking/WhenCalledWith_ThenThrowOnce.cls): spy configured with a matcher to throw once
 - [WhenCalledWithoutMatchingConfiguration](force-app/recipes/classes/mocking/WhenCalledWithoutMatchingConfiguration.cls): spy configured and called without matching parameters
 
 #### Asserting

--- a/README.md
+++ b/README.md
@@ -218,9 +218,10 @@ Have a look at the [mocking recipes](force-app/recipes/classes/mocking/) to have
 The order of the spy configuration drive how it will behave.
 
 1. If no configuration at all, then return null (default behavior).
-1. Then, it checks the `whenCalledWith` configurations.
-1. Then, it checks the global `returns` configurations.
-1. Then, it checks the global `throwsException` configurations.
+1. Then, it checks the "matching" `whenCalledWith` `once` configurations and apply them in setup order.
+1. Then, it checks the "global once" (`returnsOnce` or `throwsExceptionOnce`) configuration and apply them in setup order.
+1. Then, it checks the "matching" `whenCalledWith` configurations and apply them in setup order.
+1. Then, it checks the "global" (`returns` or `throwsException`) configurations and apply them in setup order.
 
 If there is a configuration and it does not match then it throws a `ConfigurationException`.
 The error message will contains the arguments and the configuration.

--- a/force-app/recipes/classes/ApexMockeryOverview.cls
+++ b/force-app/recipes/classes/ApexMockeryOverview.cls
@@ -12,7 +12,7 @@ private class ApexMockeryOverview {
     Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
     MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
-    planDeliverySpy.whenCalledWith(new Pastry('Chocolatine')).thenReturn(Date.today().addDays(3));
+    planDeliverySpy.whenCalledWith(new Pastry('Chocolatine')).thenReturn(Date.today().addDays(3)).thenReturnOnce(Date.today().addDays(2));
     planDeliverySpy.whenCalledWith(new OperaPastryMatchable()).thenThrow(new RecipeException());
     planDeliverySpy.returns(Date.today().addDays(4));
 
@@ -20,11 +20,20 @@ private class ApexMockeryOverview {
     Expect.that(planDeliverySpy).hasBeenCalledTimes(0);
 
     // Act & Assert
+    // Once matcher (imagine first command is delivered early)
     OrderConfirmation order = myBakery.order(new Pastry('Chocolatine'));
     Expect.that(planDeliverySpy).hasBeenCalled();
     Expect.that(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
     Expect.that(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Chocolatine'));
     Expect.that(planDeliverySpy).hasBeenCalledTimes(1);
+    Assert.areEqual(Date.today().addDays(2), order.deliveryDate);
+
+    // Matcher
+    order = myBakery.order(new Pastry('Chocolatine'));
+    Expect.that(planDeliverySpy).hasBeenCalled();
+    Expect.that(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
+    Expect.that(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Chocolatine'));
+    Expect.that(planDeliverySpy).hasBeenCalledTimes(2);
     Assert.areEqual(Date.today().addDays(3), order.deliveryDate);
 
     order = myBakery.order(new Pastry('Croissant'));
@@ -32,7 +41,7 @@ private class ApexMockeryOverview {
     Expect.that(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
     Expect.that(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
     Expect.that(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Croissant'));
-    Expect.that(planDeliverySpy).hasBeenCalledTimes(2);
+    Expect.that(planDeliverySpy).hasBeenCalledTimes(3);
     Assert.areEqual(Date.today().addDays(4), order.deliveryDate);
 
     try {

--- a/force-app/recipes/classes/mocking/ReturnsOnce.cls
+++ b/force-app/recipes/classes/mocking/ReturnsOnce.cls
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+@isTest
+private class ReturnsOnce {
+  @isTest
+  static void recipe() {
+    // Arrange
+    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
+    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
+    planDeliverySpy.throwsException(new RecipeException());
+    planDeliverySpy.returnsOnce(Date.today().addDays(3));
+
+    // Act
+    OrderConfirmation order = myBakery.order(new Pastry('Opera'));
+
+    // Assert
+    Assert.areEqual(Date.today().addDays(3), order.deliveryDate);
+
+    // Act
+    try {
+      myBakery.order(new Pastry('Opera'));
+
+      // Assert
+      Assert.fail('Expected exception was not thrown');
+    } catch (Exception ex) {
+      Assert.isInstanceOfType(ex, RecipeException.class);
+    }
+  }
+}

--- a/force-app/recipes/classes/mocking/ReturnsOnce.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/ReturnsOnce.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/recipes/classes/mocking/ThrowsOnce.cls
+++ b/force-app/recipes/classes/mocking/ThrowsOnce.cls
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+@isTest
+private class ThrowsOnce {
+  @isTest
+  static void recipe() {
+    // Arrange
+    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
+    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
+    planDeliverySpy.returns(Date.today().addDays(3));
+    planDeliverySpy.throwsExceptionOnce(new RecipeException());
+
+    // Act
+    try {
+      myBakery.order(new Pastry('Opera'));
+
+      // Assert
+      Assert.fail('Expected exception was not thrown');
+    } catch (Exception ex) {
+      Assert.isInstanceOfType(ex, RecipeException.class);
+    }
+
+    // Act
+    OrderConfirmation order = myBakery.order(new Pastry('Opera'));
+
+    // Assert
+    Assert.areEqual(Date.today().addDays(3), order.deliveryDate);
+  }
+}

--- a/force-app/recipes/classes/mocking/ThrowsOnce.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/ThrowsOnce.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWith_ThenReturnOnce.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWith_ThenReturnOnce.cls
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+@isTest
+private class WhenCalledWith_ThenReturnOnce {
+  @isTest
+  static void recipe() {
+    // Arrange
+    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
+    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
+    planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenThrow(new RecipeException());
+    planDeliverySpy.whenCalledWith(new Pastry('Croissant')).thenReturnOnce(Date.today().addDays(3));
+
+    // Act
+    OrderConfirmation order = myBakery.order(new Pastry('Croissant'));
+
+    // Assert
+    Assert.areEqual(Date.today().addDays(3), order.deliveryDate);
+
+    // Act
+    try {
+      myBakery.order(new Pastry('Croissant'));
+
+      // Assert
+      Assert.fail('Expected exception was not thrown');
+    } catch (Exception ex) {
+      Assert.isInstanceOfType(ex, RecipeException.class);
+    }
+  }
+}

--- a/force-app/recipes/classes/mocking/WhenCalledWith_ThenReturnOnce.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWith_ThenReturnOnce.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrowOnce.cls
+++ b/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrowOnce.cls
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+@isTest
+private class WhenCalledWith_ThenThrowOnce {
+  @isTest
+  static void recipe() {
+    // Arrange
+    Mock deliveryServiceMock = Mock.forType(DeliveryService.class);
+    MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
+    Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
+    planDeliverySpy.whenCalledWith(new Pastry('Opera')).thenReturn(Date.today().addDays(3));
+    planDeliverySpy.whenCalledWith(new Pastry('Opera')).thenThrowOnce(new RecipeException());
+
+    // Act
+    try {
+      myBakery.order(new Pastry('Opera'));
+
+      // Assert
+      Assert.fail('Expected exception was not thrown');
+    } catch (Exception ex) {
+      Assert.isInstanceOfType(ex, RecipeException.class);
+    }
+
+    // Act
+    OrderConfirmation order = myBakery.order(new Pastry('Opera'));
+
+    // Assert
+    Assert.areEqual(Date.today().addDays(3), order.deliveryDate);
+  }
+}

--- a/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrowOnce.cls-meta.xml
+++ b/force-app/recipes/classes/mocking/WhenCalledWith_ThenThrowOnce.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -247,7 +247,21 @@ global class MethodSpy {
     }
 
     public override String toString() {
-      return 'whenCalledWith' + this.argsMatchable + '' + (this.shouldThrow() ? '.thenThrow(' + this.error + ')' : '.thenReturn(' + this.value + ')');
+      final List<String> oncesString = new List<String>();
+      for (Exception e : this.exceptionsOnce) {
+        oncesString.add('.thenThrowOnce(' + e + ')');
+      }
+      for (Object o : this.valuesOnce) {
+        oncesString.add('.thenReturnOnce(' + o + ')');
+      }
+
+      return 'whenCalledWith' +
+        this.argsMatchable +
+        '' +
+        String.join(oncesString, '') +
+        (!this.valuesOnce.isEmpty() ? 'thenReturnOnce(' + this.valuesOnce + ')' : '') +
+        (this.error != null ? '.thenThrow(' + this.error + ')' : '') +
+        (this.value != null ? '.thenReturn(' + this.value + ')' : '');
     }
   }
 

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -235,7 +235,7 @@ global class MethodSpy {
     }
 
     public Boolean shouldThrow() {
-      return this.error != null;
+      return this.error != null || !this.exceptionsOnce.isEmpty();
     }
 
     public Boolean matches(final List<Object> callArguments) {

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -181,6 +181,7 @@ global class MethodSpy {
     MethodSpyCall thenReturn(Object value);
     MethodSpyCall thenThrow(Exception error);
     MethodSpyCall thenReturnOnce(Object value);
+    MethodSpyCall thenThrowOnce(Exception error);
     Boolean matches(List<Object> callArguments);
     Object getValue();
     Exception getException();
@@ -197,6 +198,7 @@ global class MethodSpy {
     public ParameterizedMethodSpyCall(final List<Argument.Matchable> argsMatchable) {
       this.argsMatchable = argsMatchable;
       this.valuesOnce = new List<Object>();
+      this.exceptionsOnce = new List<Exception>();
     }
 
     public MethodSpyCall thenReturnOnce(final Object value) {
@@ -208,8 +210,9 @@ global class MethodSpy {
       return this;
     }
 
-    public void thenThrowOnce(Exception error) {
-      // TODO Implementatiopn
+    public MethodSpyCall thenThrowOnce(final Exception error) {
+      this.exceptionsOnce.add(error);
+      return this;
     }
 
     public MethodSpyCall thenThrow(final Exception error) {
@@ -225,6 +228,9 @@ global class MethodSpy {
     }
 
     public Exception getException() {
+      if (!this.exceptionsOnce.isEmpty()) {
+        return this.exceptionsOnce.remove(0);
+      }
       return this.error;
     }
 

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -16,22 +16,18 @@
  */
 @IsTest
 global class MethodSpy {
-  private static String DEFAULT_MEMORY_ADDRESS = '';
-
   global final String methodName { get; private set; }
   global final CallLog callLog { get; private set; }
   private final List<ParameterizedMethodSpyCall> methodCalls;
-  private final List<OnceHolder> onceHolders;
-  private Object returnValue;
-  private Exception exceptionToThrow;
+  private final List<ConfiguredBehavior> configuredBehaviorOnces;
+  private ConfiguredBehavior returnBehavior;
+  private ConfiguredBehavior exceptionBehavior;
 
   global MethodSpy(String methodName) {
     this.methodName = methodName;
     this.callLog = new CallLog();
     this.methodCalls = new List<ParameterizedMethodSpyCall>();
-    this.onceHolders = new List<OnceHolder>();
-    this.returnValue = DEFAULT_MEMORY_ADDRESS;
-    this.exceptionToThrow = null;
+    this.configuredBehaviorOnces = new List<ConfiguredBehavior>();
   }
 
   // @deprecated use call(List<Type> paramTypes, List<String> paramNames, List<Object> args) instead
@@ -68,8 +64,8 @@ global class MethodSpy {
       }
     }
 
-    if (!this.onceHolders.isEmpty()) {
-      return this.onceHolders.remove(0).getValue();
+    if (!this.configuredBehaviorOnces.isEmpty()) {
+      return this.configuredBehaviorOnces.remove(0).getBehavior();
     }
 
     for (ParameterizedMethodSpyCall methodCall : this.methodCalls) {
@@ -78,37 +74,37 @@ global class MethodSpy {
       }
     }
 
-    if (this.exceptionToThrow != null) {
-      throw this.exceptionToThrow;
+    if (this.exceptionBehavior != null) {
+      return this.exceptionBehavior.getBehavior();
     }
 
-    if (this.returnValue !== DEFAULT_MEMORY_ADDRESS) {
-      return this.returnValue;
+    if (this.returnBehavior != null) {
+      return this.returnBehavior.getBehavior();
     }
 
     throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallTypes(paramTypes).withCallParamNames(paramNames).withCallArguments(args).build();
   }
 
   private Boolean isConfigured() {
-    return !this.methodCalls.isEmpty() || this.returnValue !== DEFAULT_MEMORY_ADDRESS || this.exceptionToThrow != null || !this.onceHolders.isEmpty();
+    return !this.methodCalls.isEmpty() || this.returnBehavior != null || this.exceptionBehavior != null || !this.configuredBehaviorOnces.isEmpty();
   }
 
   global void returns(Object value) {
-    this.exceptionToThrow = null;
-    this.returnValue = value;
+    this.exceptionBehavior = null;
+    this.returnBehavior = new ConfiguredValueBehavior(value);
   }
 
   global void throwsException(Exception exceptionToThrow) {
-    this.returnValue = DEFAULT_MEMORY_ADDRESS;
-    this.exceptionToThrow = exceptionToThrow;
+    this.returnBehavior = null;
+    this.exceptionBehavior = new ConfiguredExceptionBehavior(exceptionToThrow);
   }
 
   global void returnsOnce(Object value) {
-    this.onceHolders.add(new ValueOnceHolder(value));
+    this.configuredBehaviorOnces.add(new ConfiguredValueBehaviorOnce(value));
   }
 
   global void throwsExceptionOnce(Exception exceptionToThrowOnce) {
-    this.onceHolders.add(new ExceptionOnceHolder(exceptionToThrowOnce));
+    this.configuredBehaviorOnces.add(new ConfiguredExceptionBehaviorOnce(exceptionToThrowOnce));
   }
 
   global MethodSpyCall whenCalledWith() {
@@ -182,46 +178,45 @@ global class MethodSpy {
 
   private class ParameterizedMethodSpyCall implements MethodSpyCall {
     private final List<Argument.Matchable> argsMatchable;
-    private final List<OnceHolder> onceHolders;
-    private Object value = DEFAULT_MEMORY_ADDRESS; // It is possible to configure to return null or Exception
-    private Exception error;
+    private final List<ConfiguredBehavior> configuredBehaviorOnces;
+    private ConfiguredBehavior returnBehavior;
+    private ConfiguredBehavior exceptionBehavior;
 
     public ParameterizedMethodSpyCall(final List<Argument.Matchable> argsMatchable) {
       this.argsMatchable = argsMatchable;
-      this.onceHolders = new List<OnceHolder>();
+      this.configuredBehaviorOnces = new List<ConfiguredBehavior>();
     }
 
-    public MethodSpyCall thenReturnOnce(final Object value) {
-      this.onceHolders.add(new ValueOnceHolder(value));
-      return this;
-    }
     public MethodSpyCall thenReturn(final Object value) {
-      this.value = value;
-      this.error = null;
-      return this;
-    }
-
-    public MethodSpyCall thenThrowOnce(final Exception error) {
-      this.onceHolders.add(new ExceptionOnceHolder(error));
+      this.returnBehavior = new ConfiguredValueBehavior(value);
+      this.exceptionBehavior = null;
       return this;
     }
 
     public MethodSpyCall thenThrow(final Exception error) {
-      this.error = error;
-      this.value = DEFAULT_MEMORY_ADDRESS;
+      this.exceptionBehavior = new ConfiguredExceptionBehavior(error);
+      this.returnBehavior = null;
+      return this;
+    }
+
+    public MethodSpyCall thenReturnOnce(final Object value) {
+      this.configuredBehaviorOnces.add(new ConfiguredValueBehaviorOnce(value));
+      return this;
+    }
+
+    public MethodSpyCall thenThrowOnce(final Exception error) {
+      this.configuredBehaviorOnces.add(new ConfiguredExceptionBehaviorOnce(error));
       return this;
     }
 
     public Object getValueOnce() {
       // Check for configuration is done in matchesOnce
-      return this.onceHolders.remove(0).getValue();
+      return this.configuredBehaviorOnces.remove(0).getBehavior();
     }
 
     public Object getValue() {
-      if (this.error != null) {
-        throw this.error;
-      }
-      return this.value !== DEFAULT_MEMORY_ADDRESS ? this.value : null;
+      final ConfiguredBehavior configuredBehavior = this.exceptionBehavior != null ? this.exceptionBehavior : this.returnBehavior;
+      return configuredBehavior?.getBehavior();
     }
 
     public Boolean matches(final List<Object> callArguments) {
@@ -233,25 +228,25 @@ global class MethodSpy {
     }
 
     private Boolean isConfigured() {
-      return this.value !== DEFAULT_MEMORY_ADDRESS || this.error != null;
+      return this.returnBehavior != null || this.exceptionBehavior != null;
     }
 
     private Boolean isConfiguredOnce() {
-      return !this.onceHolders.isEmpty();
+      return !this.configuredBehaviorOnces.isEmpty();
     }
 
     public override String toString() {
       final List<String> oncesString = new List<String>();
-      for (OnceHolder onceHolder : this.onceHolders) {
-        oncesString.add(onceHolder.toString());
+      for (ConfiguredBehavior configuredBehaviorOnce : this.configuredBehaviorOnces) {
+        oncesString.add(configuredBehaviorOnce.toString());
       }
 
       return 'whenCalledWith' +
         this.argsMatchable +
         '' +
         String.join(oncesString, '') +
-        (this.error != null ? '.thenThrow(' + this.error + ')' : '') +
-        (this.value !== DEFAULT_MEMORY_ADDRESS ? '.thenReturn(' + this.value + ')' : '');
+        (this.returnBehavior != null ? this.returnBehavior.toString() : '') +
+        (this.exceptionBehavior != null ? this.exceptionBehavior.toString() : '');
     }
   }
 
@@ -303,34 +298,55 @@ global class MethodSpy {
     }
   }
 
-  private interface OnceHolder {
-    Object getValue();
-  }
+  private abstract class ConfiguredBehavior {
+    public final Object value;
+    abstract Object getBehavior();
 
-  private class ValueOnceHolder implements OnceHolder {
-    private final Object value;
-
-    public ValueOnceHolder(final Object value) {
+    public ConfiguredBehavior(final Object value) {
       this.value = value;
     }
-    public Object getValue() {
+  }
+
+  private virtual class ConfiguredValueBehavior extends ConfiguredBehavior {
+    public ConfiguredValueBehavior(final Object value) {
+      super(value);
+    }
+
+    public override Object getBehavior() {
       return this.value;
     }
 
+    public override virtual String toString() {
+      return '.thenReturn(' + this.value + ')';
+    }
+  }
+
+  private class ConfiguredValueBehaviorOnce extends ConfiguredValueBehavior {
+    public ConfiguredValueBehaviorOnce(final Object value) {
+      super(value);
+    }
     public override String toString() {
       return '.thenReturnOnce(' + this.value + ')';
     }
   }
 
-  private class ExceptionOnceHolder implements OnceHolder {
-    public final Exception value;
-
-    public ExceptionOnceHolder(final Exception value) {
-      this.value = value;
+  private virtual class ConfiguredExceptionBehavior extends ConfiguredBehavior {
+    public ConfiguredExceptionBehavior(final Exception value) {
+      super(value);
     }
 
-    public Object getValue() {
-      throw this.value;
+    public override Object getBehavior() {
+      throw (Exception) this.value;
+    }
+
+    public override virtual String toString() {
+      return '.thenThrow(' + this.value + ')';
+    }
+  }
+
+  private class ConfiguredExceptionBehaviorOnce extends ConfiguredExceptionBehavior {
+    public ConfiguredExceptionBehaviorOnce(final Exception value) {
+      super(value);
     }
 
     public override String toString() {

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -18,7 +18,7 @@
 global class MethodSpy {
   global String methodName { get; private set; }
   global CallLog callLog { get; private set; }
-  private List<ParameterizedMethodSpyCall> parameterizedMethodCalls = new List<ParameterizedMethodSpyCall>();
+  private List<MethodSpyCall> methodCalls = new List<MethodSpyCall>();
   private Object returnValue;
   private Object returnValueOnce;
   private Boolean configuredGlobalReturn = false;
@@ -67,16 +67,16 @@ global class MethodSpy {
       throw this.exceptionToThrowOnce;
     }
 
-    if (this.parameterizedMethodCalls.isEmpty() && !this.configuredGlobalReturn && !this.configuredGlobalThrow) {
+    if (this.methodCalls.isEmpty() && !this.configuredGlobalReturn && !this.configuredGlobalThrow) {
       return null;
     }
 
-    for (ParameterizedMethodSpyCall parameterizedCall : this.parameterizedMethodCalls) {
-      if (parameterizedCall.matches(args)) {
-        if (parameterizedCall.shouldThrow()) {
-          throw parameterizedCall.error;
+    for (MethodSpyCall methodCall : this.methodCalls) {
+      if (methodCall.matches(args)) {
+        if (methodCall.shouldThrow()) {
+          throw methodCall.getException();
         }
-        return parameterizedCall.value;
+        return methodCall.getValue();
       }
     }
 
@@ -141,7 +141,7 @@ global class MethodSpy {
 
   private MethodSpyCall whenCalledWithArguments(final List<Argument.Matchable> args) {
     final ParameterizedMethodSpyCall parameterizedMethodCall = new ParameterizedMethodSpyCall(args);
-    this.parameterizedMethodCalls.add(parameterizedMethodCall);
+    this.methodCalls.add(parameterizedMethodCall);
     return parameterizedMethodCall;
   }
 
@@ -178,39 +178,61 @@ global class MethodSpy {
   }
 
   global interface MethodSpyCall {
-    void thenReturn(Object value);
-    void thenThrow(Exception error);
+    MethodSpyCall thenReturn(Object value);
+    MethodSpyCall thenThrow(Exception error);
+    MethodSpyCall thenReturnOnce(Object value);
+    Boolean matches(List<Object> callArguments);
+    Object getValue();
+    Exception getException();
+    Boolean shouldThrow();
   }
 
   private class ParameterizedMethodSpyCall implements MethodSpyCall {
     private final List<Argument.Matchable> argsMatchable;
-    public Object value { get; private set; }
-    public Exception error { get; private set; }
+    private final List<Object> valuesOnce;
+    private final List<Exception> exceptionsOnce;
+    private Object value;
+    private Exception error;
 
     public ParameterizedMethodSpyCall(final List<Argument.Matchable> argsMatchable) {
       this.argsMatchable = argsMatchable;
+      this.valuesOnce = new List<Object>();
     }
 
-    public void thenReturnOnce(Object value) {
-      // TODO Implementatiopn
+    public MethodSpyCall thenReturnOnce(final Object value) {
+      this.valuesOnce.add(value);
+      return this;
     }
-    public void thenReturn(Object value) {
+    public MethodSpyCall thenReturn(final Object value) {
       this.value = value;
+      return this;
     }
 
     public void thenThrowOnce(Exception error) {
       // TODO Implementatiopn
     }
 
-    public void thenThrow(Exception error) {
+    public MethodSpyCall thenThrow(final Exception error) {
       this.error = error;
+      return this;
     }
 
-    public boolean shouldThrow() {
+    public Object getValue() {
+      if (!this.valuesOnce.isEmpty()) {
+        return this.valuesOnce.remove(0);
+      }
+      return this.value;
+    }
+
+    public Exception getException() {
+      return this.error;
+    }
+
+    public Boolean shouldThrow() {
       return this.error != null;
     }
 
-    public boolean matches(final List<Object> callArguments) {
+    public Boolean matches(final List<Object> callArguments) {
       return Argument.matches(this.argsMatchable, callArguments);
     }
 
@@ -247,7 +269,7 @@ global class MethodSpy {
 
     public ConfigurationException build() {
       List<String> errorMessages = new List<String>();
-      for (ParameterizedMethodSpyCall parameterizedCall : this.spy.parameterizedMethodCalls) {
+      for (MethodSpyCall parameterizedCall : this.spy.methodCalls) {
         errorMessages.add(parameterizedCall.toString());
       }
 

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -18,14 +18,14 @@
 global class MethodSpy {
   global final String methodName { get; private set; }
   global final CallLog callLog { get; private set; }
-  private final List<ParameterizedMethodSpyCall> methodCalls;
-  private final BehaviorManagement behaviorManager;
+  private final List<MatchingParamsMethodSpyConfig> matchingBehaviorManagers;
+  private final BehaviorManagement defaultBehaviorManager;
 
   global MethodSpy(String methodName) {
     this.methodName = methodName;
     this.callLog = new CallLog();
-    this.methodCalls = new List<ParameterizedMethodSpyCall>();
-    this.behaviorManager = new BehaviorManagement();
+    this.matchingBehaviorManagers = new List<MatchingParamsMethodSpyConfig>();
+    this.defaultBehaviorManager = new BehaviorManagement();
   }
 
   // @deprecated use call(List<Type> paramTypes, List<String> paramNames, List<Object> args) instead
@@ -56,47 +56,49 @@ global class MethodSpy {
       return null;
     }
 
-    for (ParameterizedMethodSpyCall methodCall : this.methodCalls) {
+    for (MatchingParamsMethodSpyConfig methodCall : this.matchingBehaviorManagers) {
       if (methodCall.matchesOnce(args)) {
-        return methodCall.getConfiguredBehavior();
+        return methodCall.pollConfiguredBehavior();
       }
     }
 
-    if (this.behaviorManager.hasConfiguredOnceBehavior()) {
-      return this.behaviorManager.getConfiguredBehavior();
+    if (this.defaultBehaviorManager.hasConfiguredOnceBehavior()) {
+      return this.defaultBehaviorManager.pollConfiguredBehavior();
     }
 
-    for (ParameterizedMethodSpyCall methodCall : this.methodCalls) {
+    for (MatchingParamsMethodSpyConfig methodCall : this.matchingBehaviorManagers) {
       if (methodCall.matches(args)) {
-        return methodCall.getConfiguredBehavior();
+        return methodCall.pollConfiguredBehavior();
       }
     }
 
-    if (this.behaviorManager.hasConfiguredGeneralBehavior()) {
-      return this.behaviorManager.getConfiguredBehavior();
+    if (this.defaultBehaviorManager.hasConfiguredGeneralBehavior()) {
+      return this.defaultBehaviorManager.pollConfiguredBehavior();
     }
 
     throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallTypes(paramTypes).withCallParamNames(paramNames).withCallArguments(args).build();
   }
 
   private Boolean isConfigured() {
-    return this.methodCalls.size() > 0 || this.behaviorManager.hasConfiguredOnceBehavior() || this.behaviorManager.hasConfiguredGeneralBehavior();
+    return this.matchingBehaviorManagers.size() > 0 ||
+      this.defaultBehaviorManager.hasConfiguredOnceBehavior() ||
+      this.defaultBehaviorManager.hasConfiguredGeneralBehavior();
   }
 
   global void returns(Object value) {
-    this.behaviorManager.setGeneralBehavior(new ConfiguredValueBehavior(value));
+    this.defaultBehaviorManager.configureDefault(new ConfiguredValueBehavior(value));
   }
 
   global void throwsException(Exception exceptionToThrow) {
-    this.behaviorManager.setGeneralBehavior(new ConfiguredExceptionBehavior(exceptionToThrow));
+    this.defaultBehaviorManager.configureDefault(new ConfiguredExceptionBehavior(exceptionToThrow));
   }
 
   global void returnsOnce(Object value) {
-    this.behaviorManager.queueOnceBehavior(new ConfiguredValueBehaviorOnce(value));
+    this.defaultBehaviorManager.configureOnce(new ConfiguredValueBehaviorOnce(value));
   }
 
   global void throwsExceptionOnce(Exception exceptionToThrowOnce) {
-    this.behaviorManager.queueOnceBehavior(new ConfiguredExceptionBehaviorOnce(exceptionToThrowOnce));
+    this.defaultBehaviorManager.configureOnce(new ConfiguredExceptionBehaviorOnce(exceptionToThrowOnce));
   }
 
   global MethodSpyCall whenCalledWith() {
@@ -124,8 +126,8 @@ global class MethodSpy {
   }
 
   private MethodSpyCall whenCalledWithArguments(final List<Argument.Matchable> args) {
-    final ParameterizedMethodSpyCall parameterizedMethodCall = new ParameterizedMethodSpyCall(args);
-    this.methodCalls.add(parameterizedMethodCall);
+    final MatchingParamsMethodSpyConfig parameterizedMethodCall = new MatchingParamsMethodSpyConfig(args);
+    this.matchingBehaviorManagers.add(parameterizedMethodCall);
     return parameterizedMethodCall;
   }
 
@@ -168,49 +170,49 @@ global class MethodSpy {
     MethodSpyCall thenThrowOnce(Exception error);
   }
 
-  private class ParameterizedMethodSpyCall implements MethodSpyCall {
+  private class MatchingParamsMethodSpyConfig implements MethodSpyCall {
     private final List<Argument.Matchable> argsMatchable;
-    private final BehaviorManagement behaviorManager;
+    private final BehaviorManagement defaultBehaviorManager;
 
-    public ParameterizedMethodSpyCall(final List<Argument.Matchable> argsMatchable) {
+    public MatchingParamsMethodSpyConfig(final List<Argument.Matchable> argsMatchable) {
       this.argsMatchable = argsMatchable;
-      this.behaviorManager = new BehaviorManagement();
+      this.defaultBehaviorManager = new BehaviorManagement();
     }
 
     public MethodSpyCall thenReturn(final Object value) {
-      this.behaviorManager.setGeneralBehavior(new ConfiguredValueBehavior(value));
+      this.defaultBehaviorManager.configureDefault(new ConfiguredValueBehavior(value));
       return this;
     }
 
     public MethodSpyCall thenThrow(final Exception exceptionToThrow) {
-      this.behaviorManager.setGeneralBehavior(new ConfiguredExceptionBehavior(exceptionToThrow));
+      this.defaultBehaviorManager.configureDefault(new ConfiguredExceptionBehavior(exceptionToThrow));
       return this;
     }
 
     public MethodSpyCall thenReturnOnce(final Object value) {
-      this.behaviorManager.queueOnceBehavior(new ConfiguredValueBehaviorOnce(value));
+      this.defaultBehaviorManager.configureOnce(new ConfiguredValueBehaviorOnce(value));
       return this;
     }
 
     public MethodSpyCall thenThrowOnce(final Exception exceptionToThrowOnce) {
-      this.behaviorManager.queueOnceBehavior(new ConfiguredExceptionBehaviorOnce(exceptionToThrowOnce));
+      this.defaultBehaviorManager.configureOnce(new ConfiguredExceptionBehaviorOnce(exceptionToThrowOnce));
       return this;
     }
 
-    public Object getConfiguredBehavior() {
-      return this.behaviorManager.getConfiguredBehavior();
+    public Object pollConfiguredBehavior() {
+      return this.defaultBehaviorManager.pollConfiguredBehavior();
     }
 
     public Boolean matches(final List<Object> callArguments) {
-      return this.behaviorManager.hasConfiguredGeneralBehavior() && Argument.matches(this.argsMatchable, callArguments);
+      return this.defaultBehaviorManager.hasConfiguredGeneralBehavior() && Argument.matches(this.argsMatchable, callArguments);
     }
 
     public Boolean matchesOnce(final List<Object> callArguments) {
-      return this.behaviorManager.hasConfiguredOnceBehavior() && Argument.matches(this.argsMatchable, callArguments);
+      return this.defaultBehaviorManager.hasConfiguredOnceBehavior() && Argument.matches(this.argsMatchable, callArguments);
     }
 
     public override String toString() {
-      return 'whenCalledWith' + this.argsMatchable + this.behaviorManager;
+      return 'whenCalledWith' + this.argsMatchable + this.defaultBehaviorManager;
     }
   }
 
@@ -242,7 +244,7 @@ global class MethodSpy {
 
     public ConfigurationException build() {
       List<String> errorMessages = new List<String>();
-      for (MethodSpyCall methodCall : this.spy.methodCalls) {
+      for (MethodSpyCall methodCall : this.spy.matchingBehaviorManagers) {
         errorMessages.add(methodCall.toString());
       }
 
@@ -266,11 +268,11 @@ global class MethodSpy {
     private final List<ConfiguredBehavior> onceBehaviors = new List<ConfiguredBehavior>();
     private ConfiguredBehavior generalBehavior;
 
-    public void queueOnceBehavior(final ConfiguredBehavior configuredBehavior) {
+    public void configureOnce(final ConfiguredBehavior configuredBehavior) {
       this.onceBehaviors.add(configuredBehavior);
     }
 
-    public void setGeneralBehavior(final ConfiguredBehavior configuredBehavior) {
+    public void configureDefault(final ConfiguredBehavior configuredBehavior) {
       this.generalBehavior = configuredBehavior;
     }
 
@@ -282,9 +284,9 @@ global class MethodSpy {
       return this.generalBehavior != null;
     }
 
-    public Object getConfiguredBehavior() {
+    public Object pollConfiguredBehavior() {
       final ConfiguredBehavior behaviorToApply = this.hasConfiguredOnceBehavior() ? this.onceBehaviors.remove(0) : this.generalBehavior;
-      return behaviorToApply?.getBehavior();
+      return behaviorToApply?.apply();
     }
 
     public override String toString() {

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -77,10 +77,18 @@ global class MethodSpy {
     throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallTypes(paramTypes).withCallParamNames(paramNames).withCallArguments(args).build();
   }
 
+  global void returnsOnce(Object value) {
+    // TODO Implementatiopn
+  }
+
   global void returns(Object value) {
     this.configuredGlobalReturn = true;
     this.configuredGlobalThrow = false;
     this.returnValue = value;
+  }
+
+  global void throwsExceptionOnce(Exception exceptionToThrow) {
+    // TODO Implementatiopn
   }
 
   global void throwsException(Exception exceptionToThrow) {
@@ -165,8 +173,15 @@ global class MethodSpy {
       this.argsMatchable = argsMatchable;
     }
 
+    public void thenReturnOnce(Object value) {
+      // TODO Implementatiopn
+    }
     public void thenReturn(Object value) {
       this.value = value;
+    }
+
+    public void thenThrowOnce(Exception error) {
+      // TODO Implementatiopn
     }
 
     public void thenThrow(Exception error) {

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -19,15 +19,13 @@ global class MethodSpy {
   global final String methodName { get; private set; }
   global final CallLog callLog { get; private set; }
   private final List<ParameterizedMethodSpyCall> methodCalls;
-  private final List<ConfiguredBehavior> configuredBehaviorOnces;
-  private ConfiguredBehavior returnBehavior;
-  private ConfiguredBehavior exceptionBehavior;
+  private final BehaviorManagement behaviorManager;
 
   global MethodSpy(String methodName) {
     this.methodName = methodName;
     this.callLog = new CallLog();
     this.methodCalls = new List<ParameterizedMethodSpyCall>();
-    this.configuredBehaviorOnces = new List<ConfiguredBehavior>();
+    this.behaviorManager = new BehaviorManagement();
   }
 
   // @deprecated use call(List<Type> paramTypes, List<String> paramNames, List<Object> args) instead
@@ -60,51 +58,45 @@ global class MethodSpy {
 
     for (ParameterizedMethodSpyCall methodCall : this.methodCalls) {
       if (methodCall.matchesOnce(args)) {
-        return methodCall.getValueOnce();
+        return methodCall.getConfiguredBehavior();
       }
     }
 
-    if (!this.configuredBehaviorOnces.isEmpty()) {
-      return this.configuredBehaviorOnces.remove(0).getBehavior();
+    if (this.behaviorManager.hasConfiguredOnceBehavior()) {
+      return this.behaviorManager.getConfiguredBehavior();
     }
 
     for (ParameterizedMethodSpyCall methodCall : this.methodCalls) {
       if (methodCall.matches(args)) {
-        return methodCall.getValue();
+        return methodCall.getConfiguredBehavior();
       }
     }
 
-    if (this.exceptionBehavior != null) {
-      return this.exceptionBehavior.getBehavior();
-    }
-
-    if (this.returnBehavior != null) {
-      return this.returnBehavior.getBehavior();
+    if (this.behaviorManager.hasConfiguredGeneralBehavior()) {
+      return this.behaviorManager.getConfiguredBehavior();
     }
 
     throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallTypes(paramTypes).withCallParamNames(paramNames).withCallArguments(args).build();
   }
 
   private Boolean isConfigured() {
-    return !this.methodCalls.isEmpty() || this.returnBehavior != null || this.exceptionBehavior != null || !this.configuredBehaviorOnces.isEmpty();
+    return this.methodCalls.size() > 0 || this.behaviorManager.hasConfiguredOnceBehavior() || this.behaviorManager.hasConfiguredGeneralBehavior();
   }
 
   global void returns(Object value) {
-    this.exceptionBehavior = null;
-    this.returnBehavior = new ConfiguredValueBehavior(value);
+    this.behaviorManager.setGeneralBehavior(new ConfiguredValueBehavior(value));
   }
 
   global void throwsException(Exception exceptionToThrow) {
-    this.returnBehavior = null;
-    this.exceptionBehavior = new ConfiguredExceptionBehavior(exceptionToThrow);
+    this.behaviorManager.setGeneralBehavior(new ConfiguredExceptionBehavior(exceptionToThrow));
   }
 
   global void returnsOnce(Object value) {
-    this.configuredBehaviorOnces.add(new ConfiguredValueBehaviorOnce(value));
+    this.behaviorManager.queueOnceBehavior(new ConfiguredValueBehaviorOnce(value));
   }
 
   global void throwsExceptionOnce(Exception exceptionToThrowOnce) {
-    this.configuredBehaviorOnces.add(new ConfiguredExceptionBehaviorOnce(exceptionToThrowOnce));
+    this.behaviorManager.queueOnceBehavior(new ConfiguredExceptionBehaviorOnce(exceptionToThrowOnce));
   }
 
   global MethodSpyCall whenCalledWith() {
@@ -178,75 +170,47 @@ global class MethodSpy {
 
   private class ParameterizedMethodSpyCall implements MethodSpyCall {
     private final List<Argument.Matchable> argsMatchable;
-    private final List<ConfiguredBehavior> configuredBehaviorOnces;
-    private ConfiguredBehavior returnBehavior;
-    private ConfiguredBehavior exceptionBehavior;
+    private final BehaviorManagement behaviorManager;
 
     public ParameterizedMethodSpyCall(final List<Argument.Matchable> argsMatchable) {
       this.argsMatchable = argsMatchable;
-      this.configuredBehaviorOnces = new List<ConfiguredBehavior>();
+      this.behaviorManager = new BehaviorManagement();
     }
 
     public MethodSpyCall thenReturn(final Object value) {
-      this.returnBehavior = new ConfiguredValueBehavior(value);
-      this.exceptionBehavior = null;
+      this.behaviorManager.setGeneralBehavior(new ConfiguredValueBehavior(value));
       return this;
     }
 
-    public MethodSpyCall thenThrow(final Exception error) {
-      this.exceptionBehavior = new ConfiguredExceptionBehavior(error);
-      this.returnBehavior = null;
+    public MethodSpyCall thenThrow(final Exception exceptionToThrow) {
+      this.behaviorManager.setGeneralBehavior(new ConfiguredExceptionBehavior(exceptionToThrow));
       return this;
     }
 
     public MethodSpyCall thenReturnOnce(final Object value) {
-      this.configuredBehaviorOnces.add(new ConfiguredValueBehaviorOnce(value));
+      this.behaviorManager.queueOnceBehavior(new ConfiguredValueBehaviorOnce(value));
       return this;
     }
 
-    public MethodSpyCall thenThrowOnce(final Exception error) {
-      this.configuredBehaviorOnces.add(new ConfiguredExceptionBehaviorOnce(error));
+    public MethodSpyCall thenThrowOnce(final Exception exceptionToThrowOnce) {
+      this.behaviorManager.queueOnceBehavior(new ConfiguredExceptionBehaviorOnce(exceptionToThrowOnce));
       return this;
     }
 
-    public Object getValueOnce() {
-      // Check for configuration is done in matchesOnce
-      return this.configuredBehaviorOnces.remove(0).getBehavior();
-    }
-
-    public Object getValue() {
-      final ConfiguredBehavior configuredBehavior = this.exceptionBehavior != null ? this.exceptionBehavior : this.returnBehavior;
-      return configuredBehavior?.getBehavior();
+    public Object getConfiguredBehavior() {
+      return this.behaviorManager.getConfiguredBehavior();
     }
 
     public Boolean matches(final List<Object> callArguments) {
-      return Argument.matches(this.argsMatchable, callArguments) && this.isConfigured();
+      return this.behaviorManager.hasConfiguredGeneralBehavior() && Argument.matches(this.argsMatchable, callArguments);
     }
 
     public Boolean matchesOnce(final List<Object> callArguments) {
-      return Argument.matches(this.argsMatchable, callArguments) && this.isConfiguredOnce();
-    }
-
-    private Boolean isConfigured() {
-      return this.returnBehavior != null || this.exceptionBehavior != null;
-    }
-
-    private Boolean isConfiguredOnce() {
-      return !this.configuredBehaviorOnces.isEmpty();
+      return this.behaviorManager.hasConfiguredOnceBehavior() && Argument.matches(this.argsMatchable, callArguments);
     }
 
     public override String toString() {
-      final List<String> oncesString = new List<String>();
-      for (ConfiguredBehavior configuredBehaviorOnce : this.configuredBehaviorOnces) {
-        oncesString.add(configuredBehaviorOnce.toString());
-      }
-
-      return 'whenCalledWith' +
-        this.argsMatchable +
-        '' +
-        String.join(oncesString, '') +
-        (this.returnBehavior != null ? this.returnBehavior.toString() : '') +
-        (this.exceptionBehavior != null ? this.exceptionBehavior.toString() : '');
+      return 'whenCalledWith' + this.argsMatchable + this.behaviorManager;
     }
   }
 
@@ -295,6 +259,40 @@ global class MethodSpy {
           '\nHere are the configured stubs:\n\t' +
           String.join(errorMessages, '\n\t')
       );
+    }
+  }
+
+  private class BehaviorManagement {
+    private final List<ConfiguredBehavior> onceBehaviors = new List<ConfiguredBehavior>();
+    private ConfiguredBehavior generalBehavior;
+
+    public void queueOnceBehavior(final ConfiguredBehavior configuredBehavior) {
+      this.onceBehaviors.add(configuredBehavior);
+    }
+
+    public void setGeneralBehavior(final ConfiguredBehavior configuredBehavior) {
+      this.generalBehavior = configuredBehavior;
+    }
+
+    public Boolean hasConfiguredOnceBehavior() {
+      return this.onceBehaviors.size() > 0;
+    }
+
+    public Boolean hasConfiguredGeneralBehavior() {
+      return this.generalBehavior != null;
+    }
+
+    public Object getConfiguredBehavior() {
+      final ConfiguredBehavior behaviorToApply = this.hasConfiguredOnceBehavior() ? this.onceBehaviors.remove(0) : this.generalBehavior;
+      return behaviorToApply?.getBehavior();
+    }
+
+    public override String toString() {
+      final List<String> oncesString = new List<String>();
+      for (ConfiguredBehavior configuredBehaviorOnce : this.onceBehaviors) {
+        oncesString.add(configuredBehaviorOnce.toString());
+      }
+      return String.join(oncesString, '') + (this.generalBehavior != null ? this.generalBehavior.toString() : '');
     }
   }
 

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -18,7 +18,7 @@
 global class MethodSpy {
   global String methodName { get; private set; }
   global CallLog callLog { get; private set; }
-  private List<MethodSpyCall> methodCalls = new List<MethodSpyCall>();
+  private List<ParameterizedMethodSpyCall> methodCalls = new List<ParameterizedMethodSpyCall>();
   private Object returnValue;
   private Object returnValueOnce;
   private Boolean configuredGlobalReturn = false;
@@ -71,7 +71,7 @@ global class MethodSpy {
       return null;
     }
 
-    for (MethodSpyCall methodCall : this.methodCalls) {
+    for (ParameterizedMethodSpyCall methodCall : this.methodCalls) {
       if (methodCall.matches(args)) {
         if (methodCall.shouldThrow()) {
           throw methodCall.getException();
@@ -182,10 +182,6 @@ global class MethodSpy {
     MethodSpyCall thenThrow(Exception error);
     MethodSpyCall thenReturnOnce(Object value);
     MethodSpyCall thenThrowOnce(Exception error);
-    Boolean matches(List<Object> callArguments);
-    Object getValue();
-    Exception getException();
-    Boolean shouldThrow();
   }
 
   private class ParameterizedMethodSpyCall implements MethodSpyCall {
@@ -293,8 +289,8 @@ global class MethodSpy {
 
     public ConfigurationException build() {
       List<String> errorMessages = new List<String>();
-      for (MethodSpyCall parameterizedCall : this.spy.methodCalls) {
-        errorMessages.add(parameterizedCall.toString());
+      for (MethodSpyCall methodCall : this.spy.methodCalls) {
+        errorMessages.add(methodCall.toString());
       }
 
       List<String> callArgumentsAsString = new List<String>();

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -298,21 +298,19 @@ global class MethodSpy {
     }
   }
 
-  private abstract class ConfiguredBehavior {
-    public final Object value;
-    abstract Object getBehavior();
-
-    public ConfiguredBehavior(final Object value) {
-      this.value = value;
-    }
+  private interface ConfiguredBehavior {
+    Object apply();
   }
 
-  private virtual class ConfiguredValueBehavior extends ConfiguredBehavior {
+  private virtual class ConfiguredValueBehavior implements ConfiguredBehavior {
+    public final Object value;
     public ConfiguredValueBehavior(final Object value) {
-      super(value);
+      this.value = value;
+    }
+    private ConfiguredValueBehavior() {
     }
 
-    public override Object getBehavior() {
+    public Object apply() {
       return this.value;
     }
 
@@ -323,34 +321,36 @@ global class MethodSpy {
 
   private class ConfiguredValueBehaviorOnce extends ConfiguredValueBehavior {
     public ConfiguredValueBehaviorOnce(final Object value) {
-      super(value);
+      this.value = value;
     }
     public override String toString() {
       return '.thenReturnOnce(' + this.value + ')';
     }
   }
 
-  private virtual class ConfiguredExceptionBehavior extends ConfiguredBehavior {
-    public ConfiguredExceptionBehavior(final Exception value) {
-      super(value);
+  private virtual class ConfiguredExceptionBehavior implements ConfiguredBehavior {
+    public final Exception error;
+    public ConfiguredExceptionBehavior(final Exception error) {
+      this.error = error;
+    }
+    private ConfiguredExceptionBehavior() {
     }
 
-    public override Object getBehavior() {
-      throw (Exception) this.value;
+    public Object apply() {
+      throw (Exception) this.error;
     }
 
     public override virtual String toString() {
-      return '.thenThrow(' + this.value + ')';
+      return '.thenThrow(' + this.error + ')';
     }
   }
 
   private class ConfiguredExceptionBehaviorOnce extends ConfiguredExceptionBehavior {
-    public ConfiguredExceptionBehaviorOnce(final Exception value) {
-      super(value);
+    public ConfiguredExceptionBehaviorOnce(final Exception error) {
+      this.error = error;
     }
-
     public override String toString() {
-      return '.thenThrowOnce(' + this.value + ')';
+      return '.thenThrowOnce(' + this.error + ')';
     }
   }
 

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -239,7 +239,11 @@ global class MethodSpy {
     }
 
     public Boolean matches(final List<Object> callArguments) {
-      return Argument.matches(this.argsMatchable, callArguments);
+      return Argument.matches(this.argsMatchable, callArguments) && this.isConfigured();
+    }
+
+    private Boolean isConfigured() {
+      return this.value != null || this.error != null || !this.valuesOnce.isEmpty() || !this.exceptionsOnce.isEmpty();
     }
 
     public override String toString() {

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -24,7 +24,9 @@ global class MethodSpy {
   private Boolean configuredGlobalReturn = false;
   private Boolean configuredGlobalReturnOnce = false;
   private Boolean configuredGlobalThrow = false;
+  private Boolean configuredGlobalThrowOnce = false;
   private Exception exceptionToThrow;
+  private Exception exceptionToThrowOnce;
 
   global MethodSpy(String methodName) {
     this.methodName = methodName;
@@ -59,6 +61,12 @@ global class MethodSpy {
       this.configuredGlobalReturnOnce = false;
       return this.returnValueOnce;
     }
+
+    if (this.configuredGlobalThrowOnce) {
+      this.configuredGlobalThrowOnce = false;
+      throw this.exceptionToThrowOnce;
+    }
+
     if (this.parameterizedMethodCalls.isEmpty() && !this.configuredGlobalReturn && !this.configuredGlobalThrow) {
       return null;
     }
@@ -95,14 +103,16 @@ global class MethodSpy {
     this.returnValue = value;
   }
 
-  global void throwsExceptionOnce(Exception exceptionToThrow) {
-    // TODO Implementatiopn
-  }
-
   global void throwsException(Exception exceptionToThrow) {
     this.configuredGlobalThrow = true;
     this.configuredGlobalReturn = false;
     this.exceptionToThrow = exceptionToThrow;
+  }
+
+  global void throwsExceptionOnce(Exception exceptionToThrowOnce) {
+    this.configuredGlobalThrowOnce = true;
+    this.configuredGlobalReturnOnce = false;
+    this.exceptionToThrowOnce = exceptionToThrowOnce;
   }
 
   global MethodSpyCall whenCalledWith() {

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -16,21 +16,20 @@
  */
 @IsTest
 global class MethodSpy {
-  global String methodName { get; private set; }
-  global CallLog callLog { get; private set; }
-  private List<ParameterizedMethodSpyCall> methodCalls = new List<ParameterizedMethodSpyCall>();
+  global final String methodName { get; private set; }
+  global final CallLog callLog { get; private set; }
+  private final List<ParameterizedMethodSpyCall> methodCalls;
+  private final List<OnceHolder> onceHolders;
   private Object returnValue;
-  private Object returnValueOnce;
   private Boolean configuredGlobalReturn = false;
-  private Boolean configuredGlobalReturnOnce = false;
   private Boolean configuredGlobalThrow = false;
-  private Boolean configuredGlobalThrowOnce = false;
   private Exception exceptionToThrow;
-  private Exception exceptionToThrowOnce;
 
   global MethodSpy(String methodName) {
     this.methodName = methodName;
     this.callLog = new CallLog();
+    this.methodCalls = new List<ParameterizedMethodSpyCall>();
+    this.onceHolders = new List<OnceHolder>();
   }
 
   // @deprecated use call(List<Type> paramTypes, List<String> paramNames, List<Object> args) instead
@@ -57,44 +56,39 @@ global class MethodSpy {
   public Object call(List<Type> paramTypes, List<String> paramNames, List<Object> args) {
     this.callLog.add(new MethodCall(args));
 
-    if (this.configuredGlobalReturnOnce) {
-      this.configuredGlobalReturnOnce = false;
-      return this.returnValueOnce;
-    }
-
-    if (this.configuredGlobalThrowOnce) {
-      this.configuredGlobalThrowOnce = false;
-      throw this.exceptionToThrowOnce;
-    }
-
-    if (this.methodCalls.isEmpty() && !this.configuredGlobalReturn && !this.configuredGlobalThrow) {
+    if (!this.isConfigured()) {
       return null;
     }
 
     for (ParameterizedMethodSpyCall methodCall : this.methodCalls) {
-      if (methodCall.matches(args)) {
-        if (methodCall.shouldThrow()) {
-          throw methodCall.getException();
-        }
-        return methodCall.getValue();
+      if (methodCall.matchesOnce(args)) {
+        return methodCall.getValueOnce();
       }
     }
 
-    if (this.configuredGlobalReturn) {
-      return this.returnValue;
+    if (!this.onceHolders.isEmpty()) {
+      return this.onceHolders.remove(0).getValue();
+    }
+
+    for (ParameterizedMethodSpyCall methodCall : this.methodCalls) {
+      if (methodCall.matches(args)) {
+        return methodCall.getValue();
+      }
     }
 
     if (this.configuredGlobalThrow) {
       throw this.exceptionToThrow;
     }
 
+    if (this.configuredGlobalReturn) {
+      return this.returnValue;
+    }
+
     throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallTypes(paramTypes).withCallParamNames(paramNames).withCallArguments(args).build();
   }
 
-  global void returnsOnce(Object value) {
-    this.configuredGlobalReturnOnce = true;
-    this.configuredGlobalThrowOnce = false;
-    this.returnValueOnce = value;
+  private Boolean isConfigured() {
+    return !this.methodCalls.isEmpty() || this.configuredGlobalReturn || this.configuredGlobalThrow || !this.onceHolders.isEmpty();
   }
 
   global void returns(Object value) {
@@ -109,10 +103,12 @@ global class MethodSpy {
     this.exceptionToThrow = exceptionToThrow;
   }
 
+  global void returnsOnce(Object value) {
+    this.onceHolders.add(new ValueOnceHolder(value));
+  }
+
   global void throwsExceptionOnce(Exception exceptionToThrowOnce) {
-    this.configuredGlobalThrowOnce = true;
-    this.configuredGlobalReturnOnce = false;
-    this.exceptionToThrowOnce = exceptionToThrowOnce;
+    this.onceHolders.add(new ExceptionOnceHolder(exceptionToThrowOnce));
   }
 
   global MethodSpyCall whenCalledWith() {
@@ -186,19 +182,17 @@ global class MethodSpy {
 
   private class ParameterizedMethodSpyCall implements MethodSpyCall {
     private final List<Argument.Matchable> argsMatchable;
-    private final List<Object> valuesOnce;
-    private final List<Exception> exceptionsOnce;
-    private Object value;
+    private final List<OnceHolder> onceHolders;
+    private Object value = DEFAULT_MEMORY_ADDRESS; // It is possible to configure to return null or Exception
     private Exception error;
 
     public ParameterizedMethodSpyCall(final List<Argument.Matchable> argsMatchable) {
       this.argsMatchable = argsMatchable;
-      this.valuesOnce = new List<Object>();
-      this.exceptionsOnce = new List<Exception>();
+      this.onceHolders = new List<OnceHolder>();
     }
 
     public MethodSpyCall thenReturnOnce(final Object value) {
-      this.valuesOnce.add(value);
+      this.onceHolders.add(new ValueOnceHolder(value));
       return this;
     }
     public MethodSpyCall thenReturn(final Object value) {
@@ -207,7 +201,7 @@ global class MethodSpy {
     }
 
     public MethodSpyCall thenThrowOnce(final Exception error) {
-      this.exceptionsOnce.add(error);
+      this.onceHolders.add(new ExceptionOnceHolder(error));
       return this;
     }
 
@@ -216,48 +210,46 @@ global class MethodSpy {
       return this;
     }
 
+    public Object getValueOnce() {
+      // Check for configuration is done in matchesOnce
+      return this.onceHolders.remove(0).getValue();
+    }
+
     public Object getValue() {
-      if (!this.valuesOnce.isEmpty()) {
-        return this.valuesOnce.remove(0);
+      if (this.error != null) {
+        throw this.error;
       }
-      return this.value;
-    }
-
-    public Exception getException() {
-      if (!this.exceptionsOnce.isEmpty()) {
-        return this.exceptionsOnce.remove(0);
-      }
-      return this.error;
-    }
-
-    public Boolean shouldThrow() {
-      return this.error != null || !this.exceptionsOnce.isEmpty();
+      return this.value !== DEFAULT_MEMORY_ADDRESS ? this.value : null;
     }
 
     public Boolean matches(final List<Object> callArguments) {
       return Argument.matches(this.argsMatchable, callArguments) && this.isConfigured();
     }
 
+    public Boolean matchesOnce(final List<Object> callArguments) {
+      return Argument.matches(this.argsMatchable, callArguments) && this.isConfiguredOnce();
+    }
+
     private Boolean isConfigured() {
-      return this.value != null || this.error != null || !this.valuesOnce.isEmpty() || !this.exceptionsOnce.isEmpty();
+      return this.value !== DEFAULT_MEMORY_ADDRESS || this.error != null;
+    }
+
+    private Boolean isConfiguredOnce() {
+      return !this.onceHolders.isEmpty();
     }
 
     public override String toString() {
       final List<String> oncesString = new List<String>();
-      for (Exception e : this.exceptionsOnce) {
-        oncesString.add('.thenThrowOnce(' + e + ')');
-      }
-      for (Object o : this.valuesOnce) {
-        oncesString.add('.thenReturnOnce(' + o + ')');
+      for (OnceHolder onceHolder : this.onceHolders) {
+        oncesString.add(onceHolder.toString());
       }
 
       return 'whenCalledWith' +
         this.argsMatchable +
         '' +
         String.join(oncesString, '') +
-        (!this.valuesOnce.isEmpty() ? 'thenReturnOnce(' + this.valuesOnce + ')' : '') +
         (this.error != null ? '.thenThrow(' + this.error + ')' : '') +
-        (this.value != null ? '.thenReturn(' + this.value + ')' : '');
+        (this.value !== DEFAULT_MEMORY_ADDRESS ? '.thenReturn(' + this.value + ')' : '');
     }
   }
 
@@ -308,6 +300,43 @@ global class MethodSpy {
       );
     }
   }
+
+  private interface OnceHolder {
+    Object getValue();
+  }
+
+  private class ValueOnceHolder implements OnceHolder {
+    private final Object value;
+
+    public ValueOnceHolder(final Object value) {
+      this.value = value;
+    }
+    public Object getValue() {
+      return this.value;
+    }
+
+    public override String toString() {
+      return '.thenReturnOnce(' + this.value + ')';
+    }
+  }
+
+  private class ExceptionOnceHolder implements OnceHolder {
+    public final Exception value;
+
+    public ExceptionOnceHolder(final Exception value) {
+      this.value = value;
+    }
+
+    public Object getValue() {
+      throw this.value;
+    }
+
+    public override String toString() {
+      return '.thenThrowOnce(' + this.value + ')';
+    }
+  }
+
+  private static String DEFAULT_MEMORY_ADDRESS = '';
 
   global class ConfigurationException extends Exception {
   }

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -20,7 +20,9 @@ global class MethodSpy {
   global CallLog callLog { get; private set; }
   private List<ParameterizedMethodSpyCall> parameterizedMethodCalls = new List<ParameterizedMethodSpyCall>();
   private Object returnValue;
+  private Object returnValueOnce;
   private Boolean configuredGlobalReturn = false;
+  private Boolean configuredGlobalReturnOnce = false;
   private Boolean configuredGlobalThrow = false;
   private Exception exceptionToThrow;
 
@@ -53,6 +55,10 @@ global class MethodSpy {
   public Object call(List<Type> paramTypes, List<String> paramNames, List<Object> args) {
     this.callLog.add(new MethodCall(args));
 
+    if (this.configuredGlobalReturnOnce) {
+      this.configuredGlobalReturnOnce = false;
+      return this.returnValueOnce;
+    }
     if (this.parameterizedMethodCalls.isEmpty() && !this.configuredGlobalReturn && !this.configuredGlobalThrow) {
       return null;
     }
@@ -78,7 +84,9 @@ global class MethodSpy {
   }
 
   global void returnsOnce(Object value) {
-    // TODO Implementatiopn
+    this.configuredGlobalReturnOnce = true;
+    this.configuredGlobalThrowOnce = false;
+    this.returnValueOnce = value;
   }
 
   global void returns(Object value) {

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -16,13 +16,13 @@
  */
 @IsTest
 global class MethodSpy {
+  private static String DEFAULT_MEMORY_ADDRESS = '';
+
   global final String methodName { get; private set; }
   global final CallLog callLog { get; private set; }
   private final List<ParameterizedMethodSpyCall> methodCalls;
   private final List<OnceHolder> onceHolders;
   private Object returnValue;
-  private Boolean configuredGlobalReturn = false;
-  private Boolean configuredGlobalThrow = false;
   private Exception exceptionToThrow;
 
   global MethodSpy(String methodName) {
@@ -30,6 +30,8 @@ global class MethodSpy {
     this.callLog = new CallLog();
     this.methodCalls = new List<ParameterizedMethodSpyCall>();
     this.onceHolders = new List<OnceHolder>();
+    this.returnValue = DEFAULT_MEMORY_ADDRESS;
+    this.exceptionToThrow = null;
   }
 
   // @deprecated use call(List<Type> paramTypes, List<String> paramNames, List<Object> args) instead
@@ -76,11 +78,11 @@ global class MethodSpy {
       }
     }
 
-    if (this.configuredGlobalThrow) {
+    if (this.exceptionToThrow != null) {
       throw this.exceptionToThrow;
     }
 
-    if (this.configuredGlobalReturn) {
+    if (this.returnValue !== DEFAULT_MEMORY_ADDRESS) {
       return this.returnValue;
     }
 
@@ -88,18 +90,16 @@ global class MethodSpy {
   }
 
   private Boolean isConfigured() {
-    return !this.methodCalls.isEmpty() || this.configuredGlobalReturn || this.configuredGlobalThrow || !this.onceHolders.isEmpty();
+    return !this.methodCalls.isEmpty() || this.returnValue !== DEFAULT_MEMORY_ADDRESS || this.exceptionToThrow != null || !this.onceHolders.isEmpty();
   }
 
   global void returns(Object value) {
-    this.configuredGlobalReturn = true;
-    this.configuredGlobalThrow = false;
+    this.exceptionToThrow = null;
     this.returnValue = value;
   }
 
   global void throwsException(Exception exceptionToThrow) {
-    this.configuredGlobalThrow = true;
-    this.configuredGlobalReturn = false;
+    this.returnValue = DEFAULT_MEMORY_ADDRESS;
     this.exceptionToThrow = exceptionToThrow;
   }
 
@@ -197,6 +197,7 @@ global class MethodSpy {
     }
     public MethodSpyCall thenReturn(final Object value) {
       this.value = value;
+      this.error = null;
       return this;
     }
 
@@ -207,6 +208,7 @@ global class MethodSpy {
 
     public MethodSpyCall thenThrow(final Exception error) {
       this.error = error;
+      this.value = DEFAULT_MEMORY_ADDRESS;
       return this;
     }
 
@@ -335,8 +337,6 @@ global class MethodSpy {
       return '.thenThrowOnce(' + this.value + ')';
     }
   }
-
-  private static String DEFAULT_MEMORY_ADDRESS = '';
 
   global class ConfigurationException extends Exception {
   }

--- a/force-app/test/namespace/classes/ApexMockeryOverview.cls
+++ b/force-app/test/namespace/classes/ApexMockeryOverview.cls
@@ -12,7 +12,7 @@ private class ApexMockeryOverview {
     mockery.Mock deliveryServiceMock = mockery.Mock.forType(DeliveryService.class, new StubBuilderImpl());
     mockery.MethodSpy planDeliverySpy = deliveryServiceMock.spyOn('planDelivery');
     Bakery myBakery = new Bakery((DeliveryService) deliveryServiceMock.stub);
-    planDeliverySpy.whenCalledWith(new Pastry('Chocolatine')).thenReturn(Date.today().addDays(3));
+    planDeliverySpy.whenCalledWith(new Pastry('Chocolatine')).thenReturn(Date.today().addDays(3)).thenReturnOnce(Date.today().addDays(2));
     planDeliverySpy.whenCalledWith(new OperaPastryMatchable()).thenThrow(new RecipeException());
     planDeliverySpy.returns(Date.today().addDays(4));
 
@@ -20,11 +20,20 @@ private class ApexMockeryOverview {
     mockery.Expect.that(planDeliverySpy).hasBeenCalledTimes(0);
 
     // Act & Assert
+    // Once matcher (imagine first command is delivered early)
     OrderConfirmation order = myBakery.order(new Pastry('Chocolatine'));
     mockery.Expect.that(planDeliverySpy).hasBeenCalled();
     mockery.Expect.that(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
     mockery.Expect.that(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Chocolatine'));
     mockery.Expect.that(planDeliverySpy).hasBeenCalledTimes(1);
+    Assert.areEqual(Date.today().addDays(2), order.deliveryDate);
+
+    // Matcher
+    order = myBakery.order(new Pastry('Chocolatine'));
+    mockery.Expect.that(planDeliverySpy).hasBeenCalled();
+    mockery.Expect.that(planDeliverySpy).hasBeenCalledWith(new Pastry('Chocolatine'));
+    mockery.Expect.that(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Chocolatine'));
+    mockery.Expect.that(planDeliverySpy).hasBeenCalledTimes(2);
     Assert.areEqual(Date.today().addDays(3), order.deliveryDate);
 
     order = myBakery.order(new Pastry('Croissant'));
@@ -32,7 +41,7 @@ private class ApexMockeryOverview {
     mockery.Expect.that(planDeliverySpy).hasBeenCalledWith(mockery.Argument.jsonEquals(new Pastry('Chocolatine')));
     mockery.Expect.that(planDeliverySpy).hasBeenCalledWith(new Pastry('Croissant'));
     mockery.Expect.that(planDeliverySpy).hasBeenLastCalledWith(new Pastry('Croissant'));
-    mockery.Expect.that(planDeliverySpy).hasBeenCalledTimes(2);
+    mockery.Expect.that(planDeliverySpy).hasBeenCalledTimes(3);
     Assert.areEqual(Date.today().addDays(4), order.deliveryDate);
 
     try {

--- a/force-app/test/package/classes/functional/FunctionalTest.cls
+++ b/force-app/test/package/classes/functional/FunctionalTest.cls
@@ -28,7 +28,7 @@ private class FunctionalTest {
 
     insertSObjectSpy.whenCalledWith(Argument.of(Argument.ofType(Account.getSObjectType()))).thenReturn(succeed('001000000000000AAA'));
 
-    insertSObjectSpy.whenCalledWith(Argument.of(Argument.ofType(Opportunity.getSObjectType()))).thenReturn(succeed('006000000000000AAA'));
+    insertSObjectSpy.whenCalledWith(Argument.of(Argument.ofType(Opportunity.getSObjectType()))).thenReturnOnce(succeed('006000000000000AAA'));
 
     BusinessService sut = new BusinessService((DMLDelegate) dmlDelegateMock.stub);
 

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
@@ -8,6 +8,62 @@
 @IsTest
 private class MethodSpyOnceTest {
   @IsTest
+  static void givenSpyConfiguredConfiguredOncesGlobalOnceConfiguredNormalAndGlobalNormal_whenCalledWithMatchingMultipleTimes_spyOnceThenGlobalOnceThenMathThenGlobalInOrderOfConfiguration() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.returnsOnce('global once');
+    sut.throwsExceptionOnce(new IllegalArgumentException('global once'));
+    sut.returns('global');
+    sut.throwsException(new IllegalArgumentException('global')); // It overrides returns
+    sut.whenCalledWith('str')
+      .thenReturn('match')
+      .thenThrow(new IllegalArgumentException('match')) // It overrides thenReturn
+      .thenReturnOnce('match once')
+      .thenThrowOnce(new IllegalArgumentException('match once'));
+
+    // Act & Assert
+    // whenCalledWith('str').thenReturnOnce('match once')
+    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('match once', resultMatcherOnce);
+
+    // whenCalledWith('str').thenThrowOnce(new IllegalArgumentException('match once'))
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match once', e.getMessage());
+    }
+
+    // .returnsOnce('global once')
+    Object resultGlobalOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('global once', resultGlobalOnce);
+
+    // .throwsExceptionOnce(new IllegalArgumentException('global once'))
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('global once', e.getMessage());
+    }
+
+    // whenCalledWith('str').thenThrow(new IllegalArgumentException('match')) => Override thenReturn('match')
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match', e.getMessage());
+    }
+
+    // .throwsException(new IllegalArgumentException('global')) => Override returns('global')
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('global', e.getMessage());
+    }
+  }
+
+  @IsTest
   static void givenSpyConfiguredWithReturnOnceThrowOnce_whenCalledMultipleTImes_spyThrowsOnceReturnsOnceThenGlobalReturnsOnceThenGlobalReturns() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
@@ -16,20 +72,18 @@ private class MethodSpyOnceTest {
     sut.whenCalledWith('str').thenReturnOnce('match').thenThrowOnce(new IllegalArgumentException('match'));
 
     // Act & Assert
-    Object resultOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('once', resultOnce);
+    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('match', resultMatcher);
     try {
       sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       Assert.areEqual('match', e.getMessage());
     }
+    Object resultOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('once', resultOnce);
 
-    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
     Object resultNoMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-
-    // Assert
-    Assert.areEqual('match', resultMatcher);
     Assert.areEqual('every', resultNoMatcher);
   }
 
@@ -127,11 +181,20 @@ private class MethodSpyOnceTest {
       Assert.areEqual('every', e.getMessage());
     }
 
+    sut.throwsExceptionOnce(new IllegalArgumentException('once'));
+
     try {
       sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       Assert.areEqual('match once', e.getMessage());
+    }
+
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('once', e.getMessage());
     }
 
     try {
@@ -148,11 +211,14 @@ private class MethodSpyOnceTest {
     MethodSpy sut = new MethodSpy('methodName');
     sut.whenCalledWith('str')
       .thenReturn('match')
-      .thenThrow(new IllegalArgumentException('match'))
+      .thenThrow(new IllegalArgumentException('match throw'))
       .thenReturnOnce('match once')
       .thenThrowOnce(new IllegalArgumentException('match once'));
 
     // Act & Assert
+    Object resultMatchOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('match once', resultMatchOnce);
+
     try {
       sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
       Assert.fail('it shoud not reach this line');
@@ -164,14 +230,15 @@ private class MethodSpyOnceTest {
       sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
-      Assert.areEqual('match', e.getMessage());
+      Assert.areEqual('match throw', e.getMessage());
     }
 
+    // As it is configured to throw it should not return
     try {
       sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
-      Assert.areEqual('match', e.getMessage());
+      Assert.areEqual('match throw', e.getMessage());
     }
   }
 
@@ -182,6 +249,9 @@ private class MethodSpyOnceTest {
     sut.whenCalledWith('str').thenReturn('match').thenReturnOnce('match once').thenThrowOnce(new IllegalArgumentException('match once'));
 
     // Act & Assert
+    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('match once', resultMatcherOnce);
+
     try {
       sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
       Assert.fail('it shoud not reach this line');
@@ -189,12 +259,7 @@ private class MethodSpyOnceTest {
       Assert.areEqual('match once', e.getMessage());
     }
 
-    // Act
-    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
     Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-
-    // Assert
-    Assert.areEqual('match once', resultMatcherOnce);
     Assert.areEqual('match', resultMatcher);
   }
 }

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
@@ -115,4 +115,60 @@ private class MethodSpyOnceTest {
       Assert.areEqual('match', e.getMessage());
     }
   }
+
+  @IsTest
+  static void givenSpyConfiguredWithMatcherThrowThrowOnceReturnReturnOnce_whenCalledWithMatchingMultipleTimes_spyThrowsOnceFirstThenThrowsAndNeverReturns() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.whenCalledWith('str')
+      .thenReturn('match')
+      .thenThrow(new IllegalArgumentException('match'))
+      .thenReturnOnce('match once')
+      .thenThrowOnce(new IllegalArgumentException('match once'));
+
+    // Act & Assert
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match once', e.getMessage());
+    }
+
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match', e.getMessage());
+    }
+
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match', e.getMessage());
+    }
+  }
+
+  @IsTest
+  static void givenSpyConfiguredWithMatcherThrowOnceReturnOnceReturn_whenCalledWithMatchingMultipleTimes_spyThrowsOnceFirstThenReturnsOnceThenReturns() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.whenCalledWith('str').thenReturn('match').thenReturnOnce('match once').thenThrowOnce(new IllegalArgumentException('match once'));
+
+    // Act & Assert
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match once', e.getMessage());
+    }
+
+    // Act
+    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+
+    // Assert
+    Assert.areEqual('match once', resultMatcherOnce);
+    Assert.areEqual('match', resultMatcher);
+  }
 }

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
@@ -25,4 +25,35 @@ private class MethodSpyOnceTest {
     Assert.areEqual('every', resultNoMatcher);
     Assert.areEqual('match', resultMatcher);
   }
+
+  @IsTest
+  static void givenSpyConfiguredWithThrowOnce_whenCalledMultipleTimes_spyThrowsOnce() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.throwsExceptionOnce(new IllegalArgumentException('once'));
+    sut.throwsException(new IllegalArgumentException('every'));
+    sut.whenCalledWith('str').thenThrow(new IllegalArgumentException('match'));
+
+    // Act & Assert
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('once', e.getMessage());
+    }
+
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('every', e.getMessage());
+    }
+
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match', e.getMessage());
+    }
+  }
 }

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
@@ -8,6 +8,32 @@
 @IsTest
 private class MethodSpyOnceTest {
   @IsTest
+  static void givenSpyConfiguredWithReturnOnceThrowOnce_whenCalledMultipleTImes_spyThrowsOnceReturnsOnceThenGlobalReturnsOnceThenGlobalReturns() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.returnsOnce('once');
+    sut.returns('every');
+    sut.whenCalledWith('str').thenReturnOnce('match').thenThrowOnce(new IllegalArgumentException('match'));
+
+    // Act & Assert
+    Object resultOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('once', resultOnce);
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match', e.getMessage());
+    }
+
+    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Object resultNoMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+
+    // Assert
+    Assert.areEqual('match', resultMatcher);
+    Assert.areEqual('every', resultNoMatcher);
+  }
+
+  @IsTest
   static void givenSpyConfiguredWithReturnOnce_whenCalledMultipleTImes_spyReturnsOnce() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
@@ -14,10 +14,10 @@ private class MethodSpyOnceTest {
     sut.returnsOnce('global once');
     sut.throwsExceptionOnce(new IllegalArgumentException('global once'));
     sut.returns('global');
-    sut.throwsException(new IllegalArgumentException('global')); // It overrides returns
+    sut.throwsException(new IllegalArgumentException('global')); // It overrides returns (last global configuration overrides)
     sut.whenCalledWith('str')
       .thenReturn('match')
-      .thenThrow(new IllegalArgumentException('match')) // It overrides thenReturn
+      .thenThrow(new IllegalArgumentException('match')) // It overrides thenReturn (last matching configuration overrides)
       .thenReturnOnce('match once')
       .thenThrowOnce(new IllegalArgumentException('match once'));
 

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+@IsTest
+private class MethodSpyOnceTest {
+  @IsTest
+  static void givenSpyConfiguredWithReturnOnce_whenCalledMultipleTImes_spyReturnsOnce() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.returnsOnce('once');
+    sut.returns('every');
+    sut.whenCalledWith('str').thenReturn('match');
+
+    // Act
+    Object resultOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+    Object resultNoMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+
+    // Assert
+    Assert.areEqual('once', resultOnce);
+    Assert.areEqual('every', resultNoMatcher);
+    Assert.areEqual('match', resultMatcher);
+  }
+}

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
@@ -56,4 +56,63 @@ private class MethodSpyOnceTest {
       Assert.areEqual('match', e.getMessage());
     }
   }
+
+  @IsTest
+  static void givenSpyConfiguredWithMatcherReturnOnce_whenCalledWithMatchingMultipleTimes_spyReturnsOnce() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.returnsOnce('once');
+    sut.returns('every');
+    sut.whenCalledWith('str').thenReturnOnce('match once').thenReturn('match');
+
+    // Act
+    Object resultOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+    Object resultNoMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+
+    // Assert
+    Assert.areEqual('once', resultOnce);
+    Assert.areEqual('every', resultNoMatcher);
+    Assert.areEqual('match once', resultMatcherOnce);
+    Assert.areEqual('match', resultMatcher);
+  }
+
+  @IsTest
+  static void givenSpyConfiguredWithMatcherThrowOnce_whenCalledWithMatchingMultipleTimes_spyThrowsOnce() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.throwsExceptionOnce(new IllegalArgumentException('once'));
+    sut.throwsException(new IllegalArgumentException('every'));
+    sut.whenCalledWith('str').thenThrowOnce(new IllegalArgumentException('match once')).thenThrow(new IllegalArgumentException('match'));
+
+    // Act & Assert
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('once', e.getMessage());
+    }
+
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('every', e.getMessage());
+    }
+
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match once', e.getMessage());
+    }
+
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match', e.getMessage());
+    }
+  }
 }

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls-meta.xml
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add "global" and "matching" `once` API
Create dedicated unit test class (can be simplify, just the first test covers every features)
Include once API in the functional test
Add recipes using the once API
Add once API definition in the Readme and in the recipes outline

closes #66 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add to the spy the capability to answer once to an event and then do something else

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit test
Functional test
Recipes