### PR TITLE
fix: case insensitive matching for mock

### DIFF
--- a/force-app/src/classes/Mock.cls
+++ b/force-app/src/classes/Mock.cls
@@ -22,8 +22,9 @@ global class Mock implements System.StubProvider {
     List<Object> listOfArgs
   ) {
     Object result;
-    if (this.spies.containsKey(stubbedMethodName)) {
-      MethodSpy spy = this.getSpy(stubbedMethodName);
+    final String key = this.getSpyKey(stubbedMethodName);
+    if (this.spies.containsKey(key)) {
+      MethodSpy spy = this.getSpy(key);
       result = spy.call(listOfParamTypes, listOfParamNames, listOfArgs);
     }
 
@@ -31,14 +32,15 @@ global class Mock implements System.StubProvider {
   }
 
   global MethodSpy spyOn(final String methodName) {
-    if (!this.spies.containsKey(methodName)) {
-      this.spies.put(methodName, new MethodSpy(methodName));
+    final String key = this.getSpyKey(methodName);
+    if (!this.spies.containsKey(key)) {
+      this.spies.put(key, new MethodSpy(methodName));
     }
-    return this.getSpy(methodName);
+    return this.getSpy(key);
   }
 
   global MethodSpy getSpy(final String methodName) {
-    return this.spies.get(methodName);
+    return this.spies.get(this.getSpyKey(methodName));
   }
 
   global static Mock forType(final Type aType) {
@@ -51,6 +53,10 @@ global class Mock implements System.StubProvider {
 
   global interface StubBuilder {
     Object build(final Type aType, System.StubProvider stubProvider);
+  }
+
+  private String getSpyKey(final String methodName) {
+    return methodName.toLowerCase();
   }
 
   private class DefaultStubBuilder implements StubBuilder {

--- a/force-app/test/package/classes/unit/MockTest.cls
+++ b/force-app/test/package/classes/unit/MockTest.cls
@@ -54,7 +54,7 @@ private class MockTest {
   }
 
   @IsTest
-  static void givenAMethodName_whenCallingSpyOnMultipleTimes_thenReturnsSameMethodSpy() {
+  static void givenAMethodName_whenCallingSpyOnMultipleTimes_thenReturnsSameMethodSpyCaseInsensitive() {
     // Arrange
     String methodName = 'methodName';
     Mock sut = Mock.forType(DummyInterface.class);
@@ -65,6 +65,21 @@ private class MockTest {
 
     // Assert
     Assert.areEqual(expected, result);
+    Assert.isTrue(expected === result);
+
+    // Act
+    result = sut.spyOn(methodName.toUpperCase());
+
+    // Assert
+    Assert.areEqual(expected, result);
+    Assert.isTrue(expected === result);
+
+    // Act
+    result = sut.spyOn(methodName.toLowerCase());
+
+    // Assert
+    Assert.areEqual(expected, result);
+    Assert.isTrue(expected === result);
   }
 
   @IsTest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Mock matching is now case insensitive, has it is in apex