### PR TITLE
fix: issue when punctual matchers are consumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,10 +484,20 @@ public class MyMatchable implements Argument.Matchable {
 
     return matches;
   }
+
+  public Boolean equals(Object obj) {
+      if (obj == null || !(obj instanceof MyMatchable)) {
+        return false;
+      }
+      MyMatchable other = (MyMatchable) obj;
+      return <this fields custom comparison with other instance>;
+    }
 }
 
 List<Argument.Matchable> args = Argument.of(new MyMatchable(), ...otherArguments);
 ```
+
+Implements the `public Boolean equals(Object obj)` method on your custom matchable so we can compare list of arguments
 
 Have a look at the [overview recipes](force-app/recipes/classes/ApexMockeryOverview.cls) to have a deeper overview of what you can do with the library
 

--- a/force-app/recipes/classes/OperaPastryMatchable.cls
+++ b/force-app/recipes/classes/OperaPastryMatchable.cls
@@ -10,4 +10,8 @@ public class OperaPastryMatchable implements Argument.Matchable {
     Pastry p = (Pastry) callArgument;
     return p.name == 'Opera';
   }
+
+  public Boolean equals(Object obj) {
+    return obj != null && obj instanceof OperaPastryMatchable;
+  }
 }

--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -117,6 +117,10 @@ global class Argument {
     public override String toString() {
       return 'any';
     }
+
+    public Boolean equals(Object obj) {
+      return obj != null && obj instanceof AnyMatchable;
+    }
   }
 
   private class EqualsMatchable implements Argument.Matchable {
@@ -143,6 +147,14 @@ global class Argument {
     public override String toString() {
       return String.valueOf(this.callArgumentToMatch);
     }
+
+    public Boolean equals(Object obj) {
+      if (obj == null || !(obj instanceof EqualsMatchable)) {
+        return false;
+      }
+      EqualsMatchable other = (EqualsMatchable) obj;
+      return this.matches(other.callArgumentToMatch);
+    }
   }
 
   private class JSONMatchable implements Argument.Matchable {
@@ -158,6 +170,14 @@ global class Argument {
 
     override public String toString() {
       return 'json(' + this.jsonValue + ')';
+    }
+
+    public Boolean equals(Object obj) {
+      if (obj == null || !(obj instanceof JSONMatchable)) {
+        return false;
+      }
+      JSONMatchable other = (JSONMatchable) obj;
+      return this.jsonValue.equals(other.jsonValue);
     }
   }
 
@@ -193,6 +213,14 @@ global class Argument {
     override public String toString() {
       return this.typeNameToMatch + '.Type';
     }
+
+    public Boolean equals(Object obj) {
+      if (obj == null || !(obj instanceof TypeMatchable)) {
+        return false;
+      }
+      TypeMatchable other = (TypeMatchable) obj;
+      return this.typeNameToMatch == other.typeNameToMatch;
+    }
   }
 
   private static String getTypeName(final Object callArgument) {
@@ -209,5 +237,23 @@ global class Argument {
   public static Type getType(final Object callArgument) {
     final String typeName = getTypeName(callArgument);
     return Type.forName(typeName);
+  }
+
+  global static Boolean areListsEqual(final List<Argument.Matchable> list1, final List<Argument.Matchable> list2) {
+    if (list1 == null || list2 == null) {
+      return list1 == list2;
+    }
+
+    final Integer size = list1.size();
+    if (size != list2.size()) {
+      return false;
+    }
+
+    for (Integer i = 0; i < size; ++i) {
+      if (list1[i] != list2[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -142,6 +142,12 @@ global class MethodSpy {
   }
 
   private MethodSpyCall whenCalledWithArguments(final List<Argument.Matchable> args) {
+    for (MatchingParamsMethodSpyConfig matchingConfig : this.matchingBehaviorManagers) {
+      if (Argument.areListsEqual(args, matchingConfig.argsMatchable)) {
+        return matchingConfig;
+      }
+    }
+
     final MatchingParamsMethodSpyConfig parameterizedMethodCall = new MatchingParamsMethodSpyConfig(args);
     this.matchingBehaviorManagers.add(parameterizedMethodCall);
     return parameterizedMethodCall;

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -56,9 +56,9 @@ global class MethodSpy {
       return null;
     }
 
-    for (MatchingParamsMethodSpyConfig methodCall : this.matchingBehaviorManagers) {
-      if (methodCall.matchesOnce(args)) {
-        return methodCall.pollConfiguredBehavior();
+    for (MatchingParamsMethodSpyConfig matchingConfig : this.matchingBehaviorManagers) {
+      if (matchingConfig.matchesOnce(args)) {
+        return matchingConfig.pollConfiguredBehavior();
       }
     }
 
@@ -66,9 +66,9 @@ global class MethodSpy {
       return this.defaultBehaviorManager.pollConfiguredBehavior();
     }
 
-    for (MatchingParamsMethodSpyConfig methodCall : this.matchingBehaviorManagers) {
-      if (methodCall.matches(args)) {
-        return methodCall.pollConfiguredBehavior();
+    for (MatchingParamsMethodSpyConfig matchingConfig : this.matchingBehaviorManagers) {
+      if (matchingConfig.matches(args)) {
+        return matchingConfig.pollConfiguredBehavior();
       }
     }
 
@@ -80,9 +80,13 @@ global class MethodSpy {
   }
 
   private Boolean isConfigured() {
-    return this.matchingBehaviorManagers.size() > 0 ||
-      this.defaultBehaviorManager.hasConfiguredOnceBehavior() ||
-      this.defaultBehaviorManager.hasConfiguredGeneralBehavior();
+    for (MatchingParamsMethodSpyConfig matchingConfig : this.matchingBehaviorManagers) {
+      if (matchingConfig.hasConfiguration()) {
+        return true;
+      }
+    }
+
+    return this.defaultBehaviorManager.hasConfiguredOnceBehavior() || this.defaultBehaviorManager.hasConfiguredGeneralBehavior();
   }
 
   global void returns(Object value) {
@@ -223,6 +227,10 @@ global class MethodSpy {
         this.defaultBehaviorManager.configureOnce(new ConfiguredExceptionBehaviorOnce(exceptionToThrowTimes));
       }
       return this;
+    }
+
+    public Boolean hasConfiguration() {
+      return this.defaultBehaviorManager.hasConfiguredOnceBehavior() || this.defaultBehaviorManager.hasConfiguredGeneralBehavior();
     }
 
     public Object pollConfiguredBehavior() {

--- a/force-app/test/package/classes/unit/ArgumentTest.cls
+++ b/force-app/test/package/classes/unit/ArgumentTest.cls
@@ -599,4 +599,133 @@ public class ArgumentTest {
     Assert.areEqual(List<Account>.class, Argument.getType(new List<Account>()));
     Assert.areEqual(ArgumentTest.class, Argument.getType(new ArgumentTest()));
   }
+
+  @IsTest
+  static void areListsEqual_whenCalledWithNull_returnsTrue() {
+    // Arrange
+    final List<Argument.Matchable> list1 = null;
+    final List<Argument.Matchable> list2 = null;
+
+    // Act
+    final Boolean result = Argument.areListsEqual(list1, list2);
+
+    // Assert
+    Assert.isTrue(result);
+  }
+
+  @IsTest
+  static void areListsEqual_whenCalledWithOneNull_returnsFalse() {
+    // Arrange
+    final List<Argument.Matchable> list1 = new List<Argument.Matchable>();
+    final List<Argument.Matchable> list2 = null;
+
+    // Act
+    Boolean result = Argument.areListsEqual(list1, list2);
+
+    // Assert
+    Assert.isFalse(result);
+
+    // Act
+    result = Argument.areListsEqual(list2, list1);
+
+    // Assert
+    Assert.isFalse(result);
+  }
+
+  @IsTest
+  static void areListsEqual_whenCalledWithDifferentListInSize_returnsFalse() {
+    // Arrange
+    final List<Argument.Matchable> list1 = new List<Argument.Matchable>{ Argument.any(), Argument.any() };
+    final List<Argument.Matchable> list2 = new List<Argument.Matchable>{ Argument.any() };
+
+    // Act
+    final Boolean result = Argument.areListsEqual(list1, list2);
+
+    // Assert
+    Assert.isFalse(result);
+  }
+
+  @IsTest
+  static void areListsEqual_whenCalledWithDifferentList_returnsFalse() {
+    // Arrange
+    final List<Argument.Matchable> list1 = new List<Argument.Matchable>{ Argument.any(), Argument.any() };
+    final List<Argument.Matchable> list2 = new List<Argument.Matchable>{ Argument.any(), Argument.equals('str') };
+
+    // Act
+    final Boolean result = Argument.areListsEqual(list1, list2);
+
+    // Assert
+    Assert.isFalse(result);
+  }
+
+  @IsTest
+  static void areListsEqual_whenCalledWithSameList_returnsFalse() {
+    // Arrange
+    final List<Argument.Matchable> list1 = new List<Argument.Matchable>{
+      Argument.any(),
+      Argument.equals('str'),
+      Argument.jsonEquals(new Account(Name = 'Test')),
+      Argument.ofType(Opportunity.getSObjectType())
+    };
+    final List<Argument.Matchable> list2 = new List<Argument.Matchable>{
+      Argument.any(),
+      Argument.equals('str'),
+      Argument.jsonEquals(new Account(Name = 'Test')),
+      Argument.ofType(Opportunity.getSObjectType())
+    };
+
+    // Act
+    final Boolean result = Argument.areListsEqual(list1, list2);
+
+    // Assert
+    Assert.isTrue(result);
+  }
+
+  @isTest
+  static void ArgumentAnyMatchable_equals_spec() {
+    // Act && Assert
+    Assert.isTrue(Argument.any() == Argument.any());
+    Assert.isFalse(Argument.any() == null);
+    Assert.isFalse(Argument.any() == Argument.equals('str'));
+    Assert.isFalse(Argument.any() == Argument.jsonEquals('str'));
+    Assert.isFalse(Argument.any() == Argument.ofType(Account.getSObjectType()));
+  }
+
+  @isTest
+  static void ArgumentEqualsMatchable_equals_spec() {
+    // Act && Assert
+    Assert.isTrue(Argument.equals(new Account()) == Argument.equals(new Account()));
+    Assert.isTrue(Argument.equals('str') == Argument.equals('str'));
+    Assert.isTrue(Argument.equals('STR') == Argument.equals('str'));
+    Assert.isFalse(Argument.equals('STR') == Argument.equals('not str'));
+    Assert.isFalse(Argument.equals('any') == Argument.any());
+    Assert.isFalse(Argument.equals(new Account()) == Argument.jsonEquals(new Account()));
+    Assert.isFalse(Argument.equals(new Account()) == Argument.ofType(Account.getSObjectType()));
+  }
+
+  @isTest
+  static void ArgumentJSONMatchable_equals_spec() {
+    // Act && Assert
+    Assert.isTrue(Argument.jsonEquals(new Account()) == Argument.jsonEquals(new Account()));
+    Assert.isTrue(Argument.jsonEquals('str') == Argument.jsonEquals('str'));
+    Assert.isFalse(Argument.jsonEquals('STR') == Argument.jsonEquals('str'));
+    Assert.isFalse(Argument.jsonEquals('STR') == Argument.jsonEquals('not str'));
+    Assert.isFalse(Argument.jsonEquals('any') == Argument.any());
+    Assert.isFalse(Argument.jsonEquals(new Account()) == Argument.equals(new Account()));
+    Assert.isFalse(Argument.jsonEquals(new Account()) == Argument.ofType(Account.getSObjectType()));
+  }
+
+  @isTest
+  static void ArgumentTypeMatchable_equals_spec() {
+    // Act && Assert
+    Assert.isTrue(Argument.ofType(Account.getSObjectType()) == Argument.ofType(Account.getSObjectType()));
+    Assert.isTrue(Argument.ofType('string') == Argument.ofType('string'));
+    Assert.isTrue(Argument.ofType(Argument.class) == Argument.ofType(Argument.class));
+    Assert.isFalse(Argument.ofType(Argument.class) == Argument.ofType(ArgumentTest.class));
+    Assert.isFalse(Argument.ofType(Account.getSObjectType()) == Argument.ofType(Opportunity.getSObjectType()));
+    Assert.isFalse(Argument.ofType('test') == Argument.ofType('other'));
+    Assert.isFalse(Argument.ofType('any') == Argument.any());
+    Assert.isFalse(Argument.ofType(Account.getSObjectType()) == Argument.equals(new Account()));
+    Assert.isFalse(Argument.ofType(Argument.class) == Argument.jsonEquals(new Account()));
+  }
 }

--- a/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyOnceTest.cls
@@ -7,259 +7,71 @@
 
 @IsTest
 private class MethodSpyOnceTest {
-  @IsTest
-  static void givenSpyConfiguredConfiguredOncesGlobalOnceConfiguredNormalAndGlobalNormal_whenCalledWithMatchingMultipleTimes_spyOnceThenGlobalOnceThenMathThenGlobalInOrderOfConfiguration() {
+  @isTest
+  static void givenSpyConfiguredToGloballyReturnsOnce_whenCalledOnce_returnsConfiguration() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
-    sut.returnsOnce('global once');
-    sut.throwsExceptionOnce(new IllegalArgumentException('global once'));
-    sut.returns('global');
-    sut.throwsException(new IllegalArgumentException('global')); // It overrides returns (last global configuration overrides)
-    sut.whenCalledWith('str')
-      .thenReturn('match')
-      .thenThrow(new IllegalArgumentException('match')) // It overrides thenReturn (last matching configuration overrides)
-      .thenReturnOnce('match once')
-      .thenThrowOnce(new IllegalArgumentException('match once'));
+    sut.returnsOnce('global');
 
-    // Act & Assert
-    // whenCalledWith('str').thenReturnOnce('match once')
-    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('match once', resultMatcherOnce);
+    // Act
+    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('global', resultMatcher);
 
-    // whenCalledWith('str').thenThrowOnce(new IllegalArgumentException('match once'))
+    // Assert
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.isNull(result);
+  }
+
+  @isTest
+  static void givenSpyConfiguredToGloballyThrowsOnce_whenCalledOnce_throwsConfiguration() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.throwsExceptionOnce(new IllegalArgumentException('global'));
+
+    // Act
     try {
       sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match once', e.getMessage());
-    }
-
-    // .returnsOnce('global once')
-    Object resultGlobalOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('global once', resultGlobalOnce);
-
-    // .throwsExceptionOnce(new IllegalArgumentException('global once'))
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('global once', e.getMessage());
-    }
-
-    // whenCalledWith('str').thenThrow(new IllegalArgumentException('match')) => Override thenReturn('match')
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match', e.getMessage());
-    }
-
-    // .throwsException(new IllegalArgumentException('global')) => Override returns('global')
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       Assert.areEqual('global', e.getMessage());
     }
-  }
-
-  @IsTest
-  static void givenSpyConfiguredWithReturnOnceThrowOnce_whenCalledMultipleTImes_spyThrowsOnceReturnsOnceThenGlobalReturnsOnceThenGlobalReturns() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.returnsOnce('once');
-    sut.returns('every');
-    sut.whenCalledWith('str').thenReturnOnce('match').thenThrowOnce(new IllegalArgumentException('match'));
-
-    // Act & Assert
-    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('match', resultMatcher);
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match', e.getMessage());
-    }
-    Object resultOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('once', resultOnce);
-
-    Object resultNoMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('every', resultNoMatcher);
-  }
-
-  @IsTest
-  static void givenSpyConfiguredWithReturnOnce_whenCalledMultipleTImes_spyReturnsOnce() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.returnsOnce('once');
-    sut.returns('every');
-    sut.whenCalledWith('str').thenReturn('match');
-
-    // Act
-    Object resultOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
-    Object resultNoMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
-    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
 
     // Assert
-    Assert.areEqual('once', resultOnce);
-    Assert.areEqual('every', resultNoMatcher);
-    Assert.areEqual('match', resultMatcher);
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.isNull(result);
   }
 
-  @IsTest
-  static void givenSpyConfiguredWithThrowOnce_whenCalledMultipleTimes_spyThrowsOnce() {
+  @isTest
+  static void givenSpyConfiguredToMatchReturnsOnce_whenCalledOnce_returnsConfiguration() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
-    sut.throwsExceptionOnce(new IllegalArgumentException('once'));
-    sut.throwsException(new IllegalArgumentException('every'));
-    sut.whenCalledWith('str').thenThrow(new IllegalArgumentException('match'));
-
-    // Act & Assert
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('once', e.getMessage());
-    }
-
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('every', e.getMessage());
-    }
-
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match', e.getMessage());
-    }
-  }
-
-  @IsTest
-  static void givenSpyConfiguredWithMatcherReturnOnce_whenCalledWithMatchingMultipleTimes_spyReturnsOnce() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.returnsOnce('once');
-    sut.returns('every');
-    sut.whenCalledWith('str').thenReturnOnce('match once').thenReturn('match');
+    sut.whenCalledWith('str').thenReturnOnce('match');
 
     // Act
-    Object resultOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
-    Object resultNoMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
-    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
     Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('match', resultMatcher);
 
     // Assert
-    Assert.areEqual('once', resultOnce);
-    Assert.areEqual('every', resultNoMatcher);
-    Assert.areEqual('match once', resultMatcherOnce);
-    Assert.areEqual('match', resultMatcher);
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.isNull(result);
   }
 
-  @IsTest
-  static void givenSpyConfiguredWithMatcherThrowOnce_whenCalledWithMatchingMultipleTimes_spyThrowsOnce() {
+  @isTest
+  static void givenSpyConfiguredToMatchThrowsOnce_whenCalledOnce_throwsConfiguration() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
-    sut.throwsExceptionOnce(new IllegalArgumentException('once'));
-    sut.throwsException(new IllegalArgumentException('every'));
-    sut.whenCalledWith('str').thenThrowOnce(new IllegalArgumentException('match once')).thenThrow(new IllegalArgumentException('match'));
+    sut.whenCalledWith('str').thenThrowOnce(new IllegalArgumentException('match'));
 
-    // Act & Assert
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('once', e.getMessage());
-    }
-
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('every', e.getMessage());
-    }
-
-    sut.throwsExceptionOnce(new IllegalArgumentException('once'));
-
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match once', e.getMessage());
-    }
-
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('once', e.getMessage());
-    }
-
+    // Act
     try {
       sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
       Assert.fail('it shoud not reach this line');
     } catch (Exception e) {
       Assert.areEqual('match', e.getMessage());
     }
-  }
 
-  @IsTest
-  static void givenSpyConfiguredWithMatcherThrowThrowOnceReturnReturnOnce_whenCalledWithMatchingMultipleTimes_spyThrowsOnceFirstThenThrowsAndNeverReturns() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.whenCalledWith('str')
-      .thenReturn('match')
-      .thenThrow(new IllegalArgumentException('match throw'))
-      .thenReturnOnce('match once')
-      .thenThrowOnce(new IllegalArgumentException('match once'));
-
-    // Act & Assert
-    Object resultMatchOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('match once', resultMatchOnce);
-
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match once', e.getMessage());
-    }
-
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match throw', e.getMessage());
-    }
-
-    // As it is configured to throw it should not return
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match throw', e.getMessage());
-    }
-  }
-
-  @IsTest
-  static void givenSpyConfiguredWithMatcherThrowOnceReturnOnceReturn_whenCalledWithMatchingMultipleTimes_spyThrowsOnceFirstThenReturnsOnceThenReturns() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.whenCalledWith('str').thenReturn('match').thenReturnOnce('match once').thenThrowOnce(new IllegalArgumentException('match once'));
-
-    // Act & Assert
-    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('match once', resultMatcherOnce);
-
-    try {
-      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-      Assert.fail('it shoud not reach this line');
-    } catch (Exception e) {
-      Assert.areEqual('match once', e.getMessage());
-    }
-
-    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    Assert.areEqual('match', resultMatcher);
+    // Assert
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.isNull(result);
   }
 }

--- a/force-app/test/package/classes/unit/MethodSpyTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyTest.cls
@@ -439,26 +439,6 @@ private class MethodSpyTest {
   }
 
   @IsTest
-  static void givenSpyConfiguredOnceToReturnOnMatchingArguments_whenCallingTheSpyWithOtherArguments_itThrowsMethodSpyConfigurationException() {
-    // Arrange
-    MethodSpy sut = new MethodSpy('methodName');
-    sut.whenCalledWith('Another Param', true).thenReturn('Expected Result');
-    sut.whenCalledWith('Expected First Param', false).thenReturn('Another expected Result');
-    sut.whenCalledWith('Expected First Param', true).thenReturn('Yet another expected Result');
-    try {
-      // Act
-      sut.call(new List<Type>{ String.class, Boolean.class }, new List<String>{ 'param', 'bool' }, new List<Object>{ 'Another Param', false });
-      Assert.fail('it shoud not reach this line');
-    } catch (MethodSpy.ConfigurationException cex) {
-      // Assert
-      Assert.areEqual(
-        'No stub value found for a call of methodName(String param[Another Param], Boolean bool[false])\nHere are the configured stubs:\n\twhenCalledWith(Another Param, true).thenReturn(Expected Result)\n\twhenCalledWith(Expected First Param, false).thenReturn(Another expected Result)\n\twhenCalledWith(Expected First Param, true).thenReturn(Yet another expected Result)',
-        cex.getMessage()
-      );
-    }
-  }
-
-  @IsTest
   static void givenSpyConfiguredToReturnOnMatchingArgumentsAndThenToReturns_whenCallingTheSpyWithArguments_itReturnExpectedValueAndFallbackToDefault() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');

--- a/force-app/test/package/classes/unit/MethodSpyTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyTest.cls
@@ -8,6 +8,29 @@
 @IsTest
 private class MethodSpyTest {
   @IsTest
+  static void givenSpyConfiguredWithArguments_whenConfiguredWithSameArgument_thenReturnSameConfiguration() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+
+    // Act
+    MethodSpy.MethodSpyCall spyCallNull = sut.whenCalledWith(null);
+    MethodSpy.MethodSpyCall spyCallString = sut.whenCalledWith('str');
+    MethodSpy.MethodSpyCall otherSpyCallNull = sut.whenCalledWith(null);
+    MethodSpy.MethodSpyCall otherSpyCallString = sut.whenCalledWith('str');
+
+    // Assert
+    Assert.areNotEqual(spyCallNull, spyCallString);
+    Assert.areNotEqual(otherSpyCallNull, spyCallString);
+    Assert.areNotEqual(spyCallNull, otherSpyCallString);
+    Assert.areNotEqual(otherSpyCallNull, otherSpyCallString);
+
+    Assert.areEqual(spyCallNull, otherSpyCallNull);
+    Assert.isTrue(spyCallNull === otherSpyCallNull);
+    Assert.areEqual(spyCallString, otherSpyCallString);
+    Assert.isTrue(spyCallString === otherSpyCallString);
+  }
+
+  @IsTest
   static void givenSpyConfiguredWithNullArguments_whenCalledWithMatching_spyIsCalled() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');

--- a/force-app/test/package/classes/unit/MethodSpyTimesTest.cls
+++ b/force-app/test/package/classes/unit/MethodSpyTimesTest.cls
@@ -8,6 +8,106 @@
 @IsTest
 private class MethodSpyTimesTest {
   @isTest
+  static void givenConfiguredSpy_whenCalled_respectTheOrderOfMatching() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.returns('global');
+    sut.throwsException(new IllegalArgumentException('global')); // It overrides returns (last global configuration overrides)
+    sut.returnsOnce('global once');
+    sut.throwsExceptionOnce(new IllegalArgumentException('global once'));
+    sut.whenCalledWith('str')
+      .thenReturn('match')
+      .thenThrow(new IllegalArgumentException('match')) // It overrides thenReturn (last matching configuration overrides)
+      .thenReturnOnce('match once')
+      .thenThrowOnce(new IllegalArgumentException('match once'))
+      .thenReturn('match times', 2)
+      .thenThrow(new IllegalArgumentException('match times'), 2);
+
+    // Act & Assert
+    // whenCalledWith('str').thenReturnOnce('match once')
+    Object resultMatcherOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('match once', resultMatcherOnce);
+
+    // whenCalledWith('str').thenThrowOnce(new IllegalArgumentException('match once'))
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match once', e.getMessage());
+    }
+
+    // whenCalledWith('str').thenReturn('match times', 2)
+    for (Integer i = 0; i < 2; ++i) {
+      Object resultMatcherTimes = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.areEqual('match times', resultMatcherTimes);
+    }
+
+    // whenCalledWith('str').thenThrow(new IllegalArgumentException('match times'), 2)
+    for (Integer i = 0; i < 2; ++i) {
+      try {
+        Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+        Assert.fail('it shoud not reach this line: ' + result);
+      } catch (Exception e) {
+        Assert.areEqual('match times', e.getMessage());
+      }
+    }
+
+    // .returnsOnce('global once')
+    Object resultGlobalOnce = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.areEqual('global once', resultGlobalOnce);
+
+    // .throwsExceptionOnce(new IllegalArgumentException('global once'))
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('global once', e.getMessage());
+    }
+
+    // whenCalledWith('str').thenThrow(new IllegalArgumentException('match')) => Override thenReturn('match')
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('match', e.getMessage());
+    }
+
+    // .throwsException(new IllegalArgumentException('global')) => Override returns('global')
+    try {
+      sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ null });
+      Assert.fail('it shoud not reach this line');
+    } catch (Exception e) {
+      Assert.areEqual('global', e.getMessage());
+    }
+  }
+
+  @IsTest
+  static void givenSpyConfigured_whenCallingTheSpyWithOtherArguments_itThrowsMethodSpyConfigurationException() {
+    // Arrange
+    MethodSpy sut = new MethodSpy('methodName');
+    sut.whenCalledWith('Another Param', true).thenReturn('Expected Result');
+    sut.whenCalledWith('Expected First Param', false)
+      .thenReturn('Another expected Result')
+      .thenReturnOnce('Another expected Result Once')
+      .thenReturn('Another expected Result Times', 2);
+    sut.whenCalledWith('Expected First Param', true)
+      .thenThrow(new IllegalArgumentException('Yet another expected Result'))
+      .thenThrowOnce(new IllegalArgumentException('Yet another expected Result Once'))
+      .thenThrow(new IllegalArgumentException('Yet another expected Result Times'), 2);
+    try {
+      // Act
+      sut.call(new List<Type>{ String.class, Boolean.class }, new List<String>{ 'param', 'bool' }, new List<Object>{ 'Another Param', false });
+      Assert.fail('it shoud not reach this line');
+    } catch (MethodSpy.ConfigurationException cex) {
+      // Assert
+      Assert.areEqual(
+        'No stub value found for a call of methodName(String param[Another Param], Boolean bool[false])\nHere are the configured stubs:\n\twhenCalledWith(Another Param, true).thenReturn(Expected Result)\n\twhenCalledWith(Expected First Param, false).thenReturnOnce(Another expected Result Once).thenReturnOnce(Another expected Result Times).thenReturnOnce(Another expected Result Times).thenReturn(Another expected Result)\n\twhenCalledWith(Expected First Param, true).thenThrowOnce(IllegalArgumentException:[]: Yet another expected Result Once).thenThrowOnce(IllegalArgumentException:[]: Yet another expected Result Times).thenThrowOnce(IllegalArgumentException:[]: Yet another expected Result Times).thenThrow(IllegalArgumentException:[]: Yet another expected Result)',
+        cex.getMessage()
+      );
+    }
+  }
+
+  @isTest
   static void givenSpyConfiguredToGloballyReturnsNTimes_whenCalledN1Times_returnsConfiguration() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
@@ -20,12 +120,12 @@ private class MethodSpyTimesTest {
     }
 
     // Assert
-    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    ASsert.isNull(resultMatcher);
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.isNull(result);
   }
 
   @isTest
-  static void givenSpyConfiguredToGloballyThrowsNTimes_whenCalledN1Times_throwssConfiguration() {
+  static void givenSpyConfiguredToGloballyThrowsNTimes_whenCalledN1Times_throwsConfiguration() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
     sut.throwsException(new IllegalArgumentException('global'), 3);
@@ -41,8 +141,8 @@ private class MethodSpyTimesTest {
     }
 
     // Assert
-    Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-    ASsert.isNull(resultMatcher);
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.isNull(result);
   }
 
   @isTest
@@ -58,12 +158,12 @@ private class MethodSpyTimesTest {
     }
 
     // Assert
-    /*Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-     ASsert.isNull(resultMatcher);*/
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.isNull(result);
   }
 
   @isTest
-  static void givenSpyConfiguredToMatchThrowsNTimes_whenCalledN1Times_throwssConfiguration() {
+  static void givenSpyConfiguredToMatchThrowsNTimes_whenCalledN1Times_throwsConfiguration() {
     // Arrange
     MethodSpy sut = new MethodSpy('methodName');
     sut.whenCalledWith('str').thenThrow(new IllegalArgumentException('match'), 3);
@@ -79,7 +179,7 @@ private class MethodSpyTimesTest {
     }
 
     // Assert
-    /*Object resultMatcher = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
-     ASsert.isNull(resultMatcher);*/
+    Object result = sut.call(new List<Type>{ String.class }, new List<String>{ 'param' }, new List<Object>{ 'str' });
+    Assert.isNull(result);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When a spy is configured to match and respond a certain number of times, it currently throws an exception if all matchers are consumed and no global matcher is present.

This PR aims to fix this behavior by returning null instead of throwing an exception when no configuration remains.