### PR TITLE
fix: documentation for `behaves` and `behavesOnce` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,13 +269,13 @@ Object result = myTypeStub.myMethod();
 Assert.areEqual('something', result);
 ```
 
-Have a look at the [Returns recipe](force-app/recipes/classes/mocking/Behave.cls)
+Have a look at the [Behave recipe](force-app/recipes/classes/mocking/Behave.cls)
 
 You can also configure it to execute the configured behavior multipe times
 
 ```java
 // Arrange
-myMethodSpy.behaves(Mocnew MockImpl()kImpl, 3);
+myMethodSpy.behaves(new MockImpl(), 3);
 for(Integer i = 0 ; i < 3 ; ++i) {
   // Act
   Object result = myTypeStub.myMethod();
@@ -298,14 +298,14 @@ class MockImpl implements MethodSpy.SpyBehavior {
 }
 
 // Arrange
-myMethodSpy.behaves(new MockImpl());
+myMethodSpy.behavesOnce(new MockImpl());
 // Act
 Object result = myTypeStub.myMethod();
 // Assert
 Assert.areEqual('something', result);
 ```
 
-Have a look at the [ReturnsOnce recipe](force-app/recipes/classes/mocking/BehaveOnce.cls)
+Have a look at the [BehaveOnce recipe](force-app/recipes/classes/mocking/BehaveOnce.cls)
 
 ##### Parameterized configuration
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fix documentation about the `behave` and `behavesOnce` global mocking methods

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I needed to use these methods for another project.
When I looked at the documentation I discovered those typos.

I want to fix the documentation so these great features are rightly highlighted and easy tu understand / use.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

By reading it duh...